### PR TITLE
made coord fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 /// A two dimensional coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Coord {
-    x: f64,
-    y: f64,
+    pub x: f64,
+    pub y: f64,
 }
 
 // These values are precomputed from the "exactinit" method of the c-source code. They should? be


### PR DESCRIPTION
I haven't used Rust in many years, but from what I remember the fields should be `pub`. Without `pub` fields or a `Coord::new` it is basically impossible to construct a `Coord`, right?