### PR TITLE
First pass at using num_traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["robustness", "stability"]
 categories = ["algorithms", "graphics", "science"]
-
-[dependencies]
-num-traits = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ keywords = ["robustness", "stability"]
 categories = ["algorithms", "graphics", "science"]
 
 [dependencies]
+num-traits = "0.2.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,10 @@
 //! guarantees that conversion from `f32` to `f64` must be exact.
 //! Note that this crate **only** supports types that can never panic when calling unwrapping `to_f64()`.
 
-use num_traits::Float;
 
 /// A two dimensional coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Coord<T: Float> {
+pub struct Coord<T: Into<f64>> {
     pub x: T,
     pub y: T,
 }
@@ -46,18 +45,19 @@ const ICCERRBOUND_A: f64 = (10.0 + 96.0 * EPSILON) * EPSILON;
 const ICCERRBOUND_B: f64 = (4.0 + 48.0 * EPSILON) * EPSILON;
 const ICCERRBOUND_C: f64 = (44.0 + 576.0 * EPSILON) * EPSILON * EPSILON;
 
-pub fn orient2d<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
+pub fn orient2d<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
+    
     let pa = Coord {
-        x: pa.x.to_f64().unwrap(),
-        y: pa.y.to_f64().unwrap(),
+        x: pa.x.into(),
+        y: pa.y.into(),
     };
     let pb = Coord {
-        x: pb.x.to_f64().unwrap(),
-        y: pb.y.to_f64().unwrap(),
+        x: pb.x.into(),
+        y: pb.y.into(),
     };
     let pc = Coord {
-        x: pc.x.to_f64().unwrap(),
-        y: pc.y.to_f64().unwrap(),
+        x: pc.x.into(),
+        y: pc.y.into(),
     };
 
     let detleft = (pa.x - pc.x) * (pb.y - pc.y);
@@ -146,22 +146,22 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
     D[dlength - 1]
 }
 
-pub fn incircle<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>) -> f64 {
+pub fn incircle<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>) -> f64 {
     let pa = Coord {
-        x: pa.x.to_f64().unwrap(),
-        y: pa.y.to_f64().unwrap(),
+        x: pa.x.into(),
+        y: pa.y.into(),
     };
     let pb = Coord {
-        x: pb.x.to_f64().unwrap(),
-        y: pb.y.to_f64().unwrap(),
+        x: pb.x.into(),
+        y: pb.y.into(),
     };
     let pc = Coord {
-        x: pc.x.to_f64().unwrap(),
-        y: pc.y.to_f64().unwrap(),
+        x: pc.x.into(),
+        y: pc.y.into(),
     };
     let pd = Coord {
-        x: pd.x.to_f64().unwrap(),
-        y: pd.y.to_f64().unwrap(),
+        x: pd.x.into(),
+        y: pd.y.into(),
     };
 
     let adx = pa.x - pd.x;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //! guarantees that conversion from `f32` to `f64` must be exact.
 //! Note that this crate **only** supports types that can never panic when calling unwrapping `to_f64()`.
 
-
 /// A two dimensional coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Coord<T: Into<f64>> {
@@ -46,7 +45,6 @@ const ICCERRBOUND_B: f64 = (4.0 + 48.0 * EPSILON) * EPSILON;
 const ICCERRBOUND_C: f64 = (44.0 + 576.0 * EPSILON) * EPSILON * EPSILON;
 
 pub fn orient2d<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
-    
     let pa = Coord {
         x: pa.x.into(),
         y: pa.y.into(),
@@ -310,29 +308,32 @@ fn incircleadapt(
 
     let mut fin2 = [0f64; 1152];
 
-    let mut aa = [0f64; 4];
-    if bdxtail != 0.0 || bdytail != 0.0 || cdxtail != 0.0 || cdytail != 0.0 {
+    let aa = if bdxtail != 0.0 || bdytail != 0.0 || cdxtail != 0.0 || cdytail != 0.0 {
         let (adxadx1, adxadx0) = square(adx);
         let (adyady1, adyady0) = square(ady);
         let (aa3, aa2, aa1, aa0) = two_two_sum(adxadx1, adxadx0, adyady1, adyady0);
-        aa = [aa0, aa1, aa2, aa3];
-    }
+        [aa0, aa1, aa2, aa3]
+    } else {
+        [0f64; 4]
+    };
 
-    let mut bb = [0f64; 4];
-    if cdxtail != 0.0 || cdytail != 0.0 || adxtail != 0.0 || adytail != 0.0 {
+    let bb = if cdxtail != 0.0 || cdytail != 0.0 || adxtail != 0.0 || adytail != 0.0 {
         let (bdxbdx1, bdxbdx0) = square(bdx);
         let (bdybdy1, bdybdy0) = square(bdy);
         let (bb3, bb2, bb1, bb0) = two_two_sum(bdxbdx1, bdxbdx0, bdybdy1, bdybdy0);
-        bb = [bb0, bb1, bb2, bb3];
-    }
+        [bb0, bb1, bb2, bb3]
+    } else {
+        [0f64; 4]
+    };
 
-    let mut cc = [0f64; 4];
-    if adxtail != 0.0 || adytail != 0.0 || bdxtail != 0.0 || bdytail != 0.0 {
+    let cc = if adxtail != 0.0 || adytail != 0.0 || bdxtail != 0.0 || bdytail != 0.0 {
         let (cdxcdx1, cdxcdx0) = square(cdx);
         let (cdycdy1, cdycdy0) = square(cdy);
         let (cc3, cc2, cc1, cc0) = two_two_sum(cdxcdx1, cdxcdx0, cdycdy1, cdycdy0);
-        cc = [cc0, cc1, cc2, cc3];
-    }
+        [cc0, cc1, cc2, cc3]
+    } else {
+        [0f64; 4]
+    };
 
     let mut axtbclen = 9;
     let mut axtbc = [0f64; 8];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,21 +87,7 @@ pub fn orient2d<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
     }
 }
 
-fn orient2dadapt<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, detsum: T) -> f64 {
-    let pa = Coord {
-        x: pa.x.to_f64().unwrap(),
-        y: pa.y.to_f64().unwrap(),
-    };
-    let pb = Coord {
-        x: pb.x.to_f64().unwrap(),
-        y: pb.y.to_f64().unwrap(),
-    };
-    let pc = Coord {
-        x: pc.x.to_f64().unwrap(),
-        y: pc.y.to_f64().unwrap(),
-    };
-    let detsum = detsum.to_f64().unwrap();
-
+fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) -> f64 {
     let acx = pa.x - pc.x;
     let bcx = pb.x - pc.x;
     let acy = pa.y - pc.y;
@@ -209,31 +195,13 @@ pub fn incircle<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>
     incircleadapt(pa, pb, pc, pd, permanent)
 }
 
-fn incircleadapt<T: Float>(
-    pa: Coord<T>,
-    pb: Coord<T>,
-    pc: Coord<T>,
-    pd: Coord<T>,
-    permanent: T,
+fn incircleadapt(
+    pa: Coord<f64>,
+    pb: Coord<f64>,
+    pc: Coord<f64>,
+    pd: Coord<f64>,
+    permanent: f64,
 ) -> f64 {
-    let pa = Coord {
-        x: pa.x.to_f64().unwrap(),
-        y: pa.y.to_f64().unwrap(),
-    };
-    let pb = Coord {
-        x: pb.x.to_f64().unwrap(),
-        y: pb.y.to_f64().unwrap(),
-    };
-    let pc = Coord {
-        x: pc.x.to_f64().unwrap(),
-        y: pc.y.to_f64().unwrap(),
-    };
-    let pd = Coord {
-        x: pd.x.to_f64().unwrap(),
-        y: pd.y.to_f64().unwrap(),
-    };
-    let permanent = permanent.to_f64().unwrap();
-
     let mut temp8 = [0f64; 8];
     let mut temp16a = [0f64; 16];
     let mut temp16b = [0f64; 16];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,22 +10,28 @@
 #![allow(non_snake_case)]
 
 //! This is a direct transcript of the sourcecode and algorithms provided by
-//! Jonathan Richard Shewchuk (https://www.cs.cmu.edu/~quake/robust.html)
+//! Jonathan Richard Shewchuk ([https://www.cs.cmu.edu/~quake/robust.html](https://www.cs.cmu.edu/~quake/robust.html))
 //! See the paper and the source code for more information.
 //!
 //! The module offers adaptive and precise calculations for orientation queries
-//! (on which side of a line lies a point?) and in circle queries
+//! (on which side of a line does a point lie?) and in-circle queries
 //! (is a given point contained in the circumference of a triangle?)
 //! The "adaptive" nature will increase performance only if a simpler calculation
-//! cannot be guaranteed to be accurate enough, yielding a higher performance on
+//! cannot be guaranteed to be accurate enough, yielding higher performance on
 //! average.
-// use crate::point_traits::PointN;
+//!
+//! The public API will accept `f32` input points for predicate checking, but these are converted to `f64` values for internal use.
+//! This has no effect on precision, as the [IEEE-754 standard](https://drive.google.com/file/d/0B3O3Ys97VjtxYXBCY08wanNoZ1U/view) (section 5.3)
+//! guarantees that conversion from `f32` to `f64` must be exact.
+//! Note that this crate **only** supports types that can never panic when calling unwrapping `to_f64()`.
+
+use num_traits::Float;
 
 /// A two dimensional coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Coord {
-    pub x: f64,
-    pub y: f64,
+pub struct Coord<T: Float> {
+    pub x: T,
+    pub y: T,
 }
 
 // These values are precomputed from the "exactinit" method of the c-source code. They should? be
@@ -40,7 +46,20 @@ const ICCERRBOUND_A: f64 = (10.0 + 96.0 * EPSILON) * EPSILON;
 const ICCERRBOUND_B: f64 = (4.0 + 48.0 * EPSILON) * EPSILON;
 const ICCERRBOUND_C: f64 = (44.0 + 576.0 * EPSILON) * EPSILON * EPSILON;
 
-pub fn orient2d(pa: Coord, pb: Coord, pc: Coord) -> f64 {
+pub fn orient2d<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
+    let pa = Coord {
+        x: pa.x.to_f64().unwrap(),
+        y: pa.y.to_f64().unwrap(),
+    };
+    let pb = Coord {
+        x: pb.x.to_f64().unwrap(),
+        y: pb.y.to_f64().unwrap(),
+    };
+    let pc = Coord {
+        x: pc.x.to_f64().unwrap(),
+        y: pc.y.to_f64().unwrap(),
+    };
+
     let detleft = (pa.x - pc.x) * (pb.y - pc.y);
     let detright = (pa.y - pc.y) * (pb.x - pc.x);
     let det = detleft - detright;
@@ -68,7 +87,21 @@ pub fn orient2d(pa: Coord, pb: Coord, pc: Coord) -> f64 {
     }
 }
 
-fn orient2dadapt(pa: Coord, pb: Coord, pc: Coord, detsum: f64) -> f64 {
+fn orient2dadapt<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, detsum: T) -> f64 {
+    let pa = Coord {
+        x: pa.x.to_f64().unwrap(),
+        y: pa.y.to_f64().unwrap(),
+    };
+    let pb = Coord {
+        x: pb.x.to_f64().unwrap(),
+        y: pb.y.to_f64().unwrap(),
+    };
+    let pc = Coord {
+        x: pc.x.to_f64().unwrap(),
+        y: pc.y.to_f64().unwrap(),
+    };
+    let detsum = detsum.to_f64().unwrap();
+
     let acx = pa.x - pc.x;
     let bcx = pb.x - pc.x;
     let acy = pa.y - pc.y;
@@ -127,7 +160,24 @@ fn orient2dadapt(pa: Coord, pb: Coord, pc: Coord, detsum: f64) -> f64 {
     D[dlength - 1]
 }
 
-pub fn incircle(pa: Coord, pb: Coord, pc: Coord, pd: Coord) -> f64 {
+pub fn incircle<T: Float>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>) -> f64 {
+    let pa = Coord {
+        x: pa.x.to_f64().unwrap(),
+        y: pa.y.to_f64().unwrap(),
+    };
+    let pb = Coord {
+        x: pb.x.to_f64().unwrap(),
+        y: pb.y.to_f64().unwrap(),
+    };
+    let pc = Coord {
+        x: pc.x.to_f64().unwrap(),
+        y: pc.y.to_f64().unwrap(),
+    };
+    let pd = Coord {
+        x: pd.x.to_f64().unwrap(),
+        y: pd.y.to_f64().unwrap(),
+    };
+
     let adx = pa.x - pd.x;
     let bdx = pb.x - pd.x;
     let cdx = pc.x - pd.x;
@@ -159,7 +209,31 @@ pub fn incircle(pa: Coord, pb: Coord, pc: Coord, pd: Coord) -> f64 {
     incircleadapt(pa, pb, pc, pd, permanent)
 }
 
-fn incircleadapt(pa: Coord, pb: Coord, pc: Coord, pd: Coord, permanent: f64) -> f64 {
+fn incircleadapt<T: Float>(
+    pa: Coord<T>,
+    pb: Coord<T>,
+    pc: Coord<T>,
+    pd: Coord<T>,
+    permanent: T,
+) -> f64 {
+    let pa = Coord {
+        x: pa.x.to_f64().unwrap(),
+        y: pa.y.to_f64().unwrap(),
+    };
+    let pb = Coord {
+        x: pb.x.to_f64().unwrap(),
+        y: pb.y.to_f64().unwrap(),
+    };
+    let pc = Coord {
+        x: pc.x.to_f64().unwrap(),
+        y: pc.y.to_f64().unwrap(),
+    };
+    let pd = Coord {
+        x: pd.x.to_f64().unwrap(),
+        y: pd.y.to_f64().unwrap(),
+    };
+    let permanent = permanent.to_f64().unwrap();
+
     let mut temp8 = [0f64; 8];
     let mut temp16a = [0f64; 16];
     let mut temp16b = [0f64; 16];
@@ -1110,16 +1184,28 @@ fn two_two_sum(a1: f64, a0: f64, b1: f64, b0: f64) -> (f64, f64, f64, f64) {
 
 #[cfg(test)]
 mod test {
-    use super::{Coord, incircle, orient2d};
+    use super::{incircle, orient2d, Coord};
 
     #[test]
     fn test_orient2d() {
         let from = Coord { x: -1f64, y: -1.0 };
         let to = Coord { x: 1f64, y: 1.0 };
-        let p1 = Coord { x: ::std::f64::MIN_POSITIVE, y: ::std::f64::MIN_POSITIVE };
-        let p2 = Coord { x: -::std::f64::MIN_POSITIVE, y: -::std::f64::MIN_POSITIVE };
-        let p3 = Coord { x: -::std::f64::MIN_POSITIVE, y: ::std::f64::MIN_POSITIVE };
-        let p4 = Coord { x: ::std::f64::MIN_POSITIVE, y: -::std::f64::MIN_POSITIVE };
+        let p1 = Coord {
+            x: ::std::f64::MIN_POSITIVE,
+            y: ::std::f64::MIN_POSITIVE,
+        };
+        let p2 = Coord {
+            x: -::std::f64::MIN_POSITIVE,
+            y: -::std::f64::MIN_POSITIVE,
+        };
+        let p3 = Coord {
+            x: -::std::f64::MIN_POSITIVE,
+            y: ::std::f64::MIN_POSITIVE,
+        };
+        let p4 = Coord {
+            x: ::std::f64::MIN_POSITIVE,
+            y: -::std::f64::MIN_POSITIVE,
+        };
 
         for &(p, sign) in &[(p1, 0.0), (p2, 0.0), (p3, 1.0), (p4, -1.0)] {
             let det = orient2d(from, to, p);
@@ -1131,8 +1217,14 @@ mod test {
     fn test_incircle() {
         let from = Coord { x: -1f64, y: -1.0 };
         let to = Coord { x: 1f64, y: 1.0 };
-        let p_left = Coord { x: -::std::f64::MIN_POSITIVE, y: ::std::f64::MIN_POSITIVE };
-        let p_right = Coord { x: ::std::f64::MIN_POSITIVE, y: -::std::f64::MIN_POSITIVE };
+        let p_left = Coord {
+            x: -::std::f64::MIN_POSITIVE,
+            y: ::std::f64::MIN_POSITIVE,
+        };
+        let p_right = Coord {
+            x: ::std::f64::MIN_POSITIVE,
+            y: -::std::f64::MIN_POSITIVE,
+        };
         let p_query = Coord { x: 2.0, y: 2.0 };
 
         assert!(incircle(from, p_left, to, p_query) > 0.0);
@@ -1141,10 +1233,22 @@ mod test {
 
     #[test]
     fn test_issue48_a() {
-        let pa = Coord { x: 2.1045541600524288e-15, y: -1.0000000000000016 };
-        let pb = Coord { x: 1.000000000000005, y: -3.350874324301223e-16 };
-        let pc = Coord { x: 7.553997323229233e-15, y: 0.9999999999999958 };
-        let pd = Coord { x: -0.9999999999999922, y: -7.073397829693697e-15 };
+        let pa = Coord {
+            x: 2.1045541600524288e-15,
+            y: -1.0000000000000016,
+        };
+        let pb = Coord {
+            x: 1.000000000000005,
+            y: -3.350874324301223e-16,
+        };
+        let pc = Coord {
+            x: 7.553997323229233e-15,
+            y: 0.9999999999999958,
+        };
+        let pd = Coord {
+            x: -0.9999999999999922,
+            y: -7.073397829693697e-15,
+        };
         // the (incorrect) result from the previous version of exactpred.rs
         assert!(incircle(pa, pb, pc, pd) != 1.9217716744382023e-16f64);
         // the result predicates.c gives
@@ -1153,14 +1257,25 @@ mod test {
 
     #[test]
     fn test_issue48_b() {
-        let pa = Coord { x: 9.128561612013288e-15, y: -1.0000000000000029 };
-        let pb = Coord { x: 1.0000000000000044, y: -5.451395142523081e-15 };
-        let pc = Coord { x: 3.851214418148064e-15, y: 0.9999999999999961 };
-        let pd = Coord { x: -0.9999999999999946, y: -6.6797960341085084e-15 };
+        let pa = Coord {
+            x: 9.128561612013288e-15,
+            y: -1.0000000000000029,
+        };
+        let pb = Coord {
+            x: 1.0000000000000044,
+            y: -5.451395142523081e-15,
+        };
+        let pc = Coord {
+            x: 3.851214418148064e-15,
+            y: 0.9999999999999961,
+        };
+        let pd = Coord {
+            x: -0.9999999999999946,
+            y: -6.6797960341085084e-15,
+        };
         // the (incorrect) result from the previous version of exactpred.rs
         assert!(incircle(pa, pb, pc, pd) != -1.1074731814540733e-16);
         // the result predicates.c gives
         assert!(incircle(pa, pb, pc, pd) == 7.226864249343135e-30);
     }
 }
-


### PR DESCRIPTION
See discussion at #3. At the moment, this change simply upcasts to `f64` where it needs to, presenting a `T: Float` public API. Not addressed in this PR is a feature flag for `f32` targets https://github.com/georust/robust/issues/3#issuecomment-586711914. I'm happy to leave that for now. Tagging @bluenote10 in too since I can't request review from him.