### PR TITLE
Use SPDX license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 homepage = "https://github.com/georust/robust"
 edition = "2018"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["robustness", "stability"]
 categories = ["algorithms", "graphics", "science"]


### PR DESCRIPTION
Uses a SPDX license expression as recommended by [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields).

This enables e.g. parsing via the [CycloneDX Rust Cargo Plugin](https://github.com/CycloneDX/cyclonedx-rust-cargo).