### PR TITLE
Use FMA (at the cost of no_std)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Coord3D<T: Into<f64>> {
 // These values are precomputed from the "exactinit" method of the c-source code. They should? be
 // the same in all IEEE-754 environments, including rust f64
 const SPLITTER: f64 = 134_217_729f64;
-const EPSILON: f64 = 0.000_000_000_000_000_111_022_302_462_515_65;
+const EPSILON: f64 = ::core::f64::EPSILON / 2.0;
 const RESULTERRBOUND: f64 = (3.0 + 8.0 * EPSILON) * EPSILON;
 const CCWERRBOUND_A: f64 = (3.0 + 16.0 * EPSILON) * EPSILON;
 const CCWERRBOUND_B: f64 = (2.0 + 12.0 * EPSILON) * EPSILON;


### PR DESCRIPTION
This PR contains a minor change (using core::f64::EPSILON / 2.0 to define EPSILON to be more descriptive) and a bigger change that uses Fused-Multiply-Add (FMA) for two_product. This simplifies the code a little and should improve performance on processors with an FMA instruction (most x86 CPUs since 2014) for the exact computations (which should rarely be called, though, for non-degenerate geometries).

Edit: If a compile-time check equivalent to the FP_FAST_FMA macro exists in Rust, the splitting version could be used for builds in which fast FMA is not enabled because I do not know how slow FMA is without CPU support for the instruction.

It comes at the cost of no_std because as I understand it, the mul_add function is only available in std. My knowledge of rust is very limited though, so maybe there is a way around that.