### PR TITLE
Make predicate implementations generic with respect to any suitable floating point type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["algorithms", "graphics", "science::geo"]
 
 [features]
 no_std = []
-f128 = []
+#f128 = []
 
 [dev-dependencies]
 png = "0.16.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["algorithms", "graphics", "science::geo"]
 
 [features]
 no_std = []
+f128 = []
 
 [dev-dependencies]
 png = "0.16.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
-#![cfg_attr(feature = "f128", feature(f128))]
+//#![cfg_attr(feature = "f128", feature(f128))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
 // Copyright 2017 The Spade Developers.
 // Copyright 2020 The GeoRust Project Developers.
@@ -128,8 +128,8 @@ macro_rules! impl_ieee754 {
 impl_ieee754!(f32);
 impl_ieee754!(f64);
 
-#[cfg(feature = "f128")]
-impl_ieee754!(f128);
+//#[cfg(feature = "f128")]
+//impl_ieee754!(f128);
 
 /// A two dimensional generic coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(feature = "f128", feature(f128))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
 // Copyright 2017 The Spade Developers.
 // Copyright 2020 The GeoRust Project Developers.
@@ -33,6 +34,118 @@
 #[cfg(test)]
 mod tests;
 
+use core::convert::From;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+
+pub trait Ieee754Float:
+    Copy
+    + PartialEq
+    + PartialOrd
+    + From<f32>
+    + From<i16>
+    + Add<Output = Self>
+    + AddAssign
+    + Mul<Output = Self>
+    + MulAssign
+    + Sub<Output = Self>
+    + Neg<Output = Self>
+{
+    const SPLITTER: Self;
+    const RESULTERRBOUND: Self;
+    const CCWERRBOUND_A: Self;
+    const CCWERRBOUND_B: Self;
+    const CCWERRBOUND_C: Self;
+    const O3DERRBOUND_A: Self;
+    const O3DERRBOUND_B: Self;
+    const O3DERRBOUND_C: Self;
+    const ICCERRBOUND_A: Self;
+    const ICCERRBOUND_B: Self;
+    const ICCERRBOUND_C: Self;
+    const ISPERRBOUND_A: Self;
+    const ISPERRBOUND_B: Self;
+    const ISPERRBOUND_C: Self;
+
+    fn abs(self) -> Self;
+}
+
+// Constant phi from https://doi.org/10.1007/s10543-015-0574-9
+// which results in a sharper CCWERRBOUND_A
+const fn phi(mantissaDigits: u32) -> i64 {
+    match mantissaDigits {
+        24 => 4_094,
+        53 => 94_906_264,
+        64 => 4_294_967_294,
+        113 => 101_904_826_760_412_360,
+        // -(6 - 22) = 16, fall-back to the generally applicable bound by Shewchuk
+        _ => 6,
+    }
+}
+
+macro_rules! impl_ieee754 {
+    ($T:ty) => {
+        impl Ieee754Float for $T {
+            const SPLITTER: $T = ((1_i64 << (Self::MANTISSA_DIGITS / 2 + 1)) + 1) as $T;
+
+            const RESULTERRBOUND: $T =
+                3.0 * (Self::EPSILON / 2.0) - 8.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            const CCWERRBOUND_A: $T = 3.0 * (Self::EPSILON / 2.0)
+                + (phi(Self::MANTISSA_DIGITS) as $T - 22.0) * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            const CCWERRBOUND_B: $T =
+                2.0 * (Self::EPSILON / 2.0) + 12.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const CCWERRBOUND_C: $T =
+                (9.0 + 16.0 * (Self::EPSILON / 2.0)) * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            const O3DERRBOUND_A: $T =
+                7.0 * (Self::EPSILON / 2.0) + 56.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const O3DERRBOUND_B: $T =
+                3.0 * (Self::EPSILON / 2.0) + 28.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const O3DERRBOUND_C: $T =
+                (26.0 + 288.0 * (Self::EPSILON / 2.0)) * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            const ICCERRBOUND_A: $T =
+                10.0 * (Self::EPSILON / 2.0) + 96.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const ICCERRBOUND_B: $T =
+                4.0 * (Self::EPSILON / 2.0) + 48.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const ICCERRBOUND_C: $T =
+                (44.0 + 576.0 * (Self::EPSILON / 2.0)) * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            const ISPERRBOUND_A: $T =
+                16.0 * (Self::EPSILON / 2.0) + 224.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const ISPERRBOUND_B: $T =
+                5.0 * (Self::EPSILON / 2.0) + 72.0 * (Self::EPSILON * Self::EPSILON / 4.0);
+            const ISPERRBOUND_C: $T =
+                (71.0 + 1408.0 * (Self::EPSILON / 2.0)) * (Self::EPSILON * Self::EPSILON / 4.0);
+
+            fn abs(self) -> $T {
+                Self::abs(self)
+            }
+        }
+    };
+}
+
+impl_ieee754!(f32);
+impl_ieee754!(f64);
+
+#[cfg(feature = "f128")]
+impl_ieee754!(f128);
+
+/// A two dimensional generic coordinate.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct CoordGeneric<T: Ieee754Float> {
+    pub x: T,
+    pub y: T,
+}
+
+/// A three dimensional generic coordinate.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Coord3DGeneric<T: Ieee754Float> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
 /// A two dimensional coordinate.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Coord<T: Into<f64>> {
@@ -48,25 +161,8 @@ pub struct Coord3D<T: Into<f64>> {
     pub z: T,
 }
 
-// These values are precomputed from the "exactinit" method of the c-source code. They should? be
-// the same in all IEEE-754 environments, including rust f64
-const SPLITTER: f64 = 134_217_729f64;
-const EPSILON: f64 = 0.000_000_000_000_000_111_022_302_462_515_65;
-const RESULTERRBOUND: f64 = (3.0 + 8.0 * EPSILON) * EPSILON;
-const CCWERRBOUND_B: f64 = (2.0 + 12.0 * EPSILON) * EPSILON;
-const CCWERRBOUND_C: f64 = (9.0 + 64.0 * EPSILON) * EPSILON * EPSILON;
-const O3DERRBOUND_A: f64 = (7.0 + 56.0 * EPSILON) * EPSILON;
-const O3DERRBOUND_B: f64 = (3.0 + 28.0 * EPSILON) * EPSILON;
-const O3DERRBOUND_C: f64 = (26.0 + 288.0 * EPSILON) * EPSILON * EPSILON;
-const ICCERRBOUND_A: f64 = (10.0 + 96.0 * EPSILON) * EPSILON;
-const ICCERRBOUND_B: f64 = (4.0 + 48.0 * EPSILON) * EPSILON;
-const ICCERRBOUND_C: f64 = (44.0 + 576.0 * EPSILON) * EPSILON * EPSILON;
-const ISPERRBOUND_A: f64 = (16.0 + 224.0 * EPSILON) * EPSILON;
-const ISPERRBOUND_B: f64 = (5.0 + 72.0 * EPSILON) * EPSILON;
-const ISPERRBOUND_C: f64 = (71.0 + 1408.0 * EPSILON) * EPSILON * EPSILON;
-
 #[inline(always)]
-fn abs(x: f64) -> f64 {
+fn abs<T: Ieee754Float>(x: T) -> T {
     x.abs()
 }
 
@@ -74,32 +170,17 @@ fn abs(x: f64) -> f64 {
 /// (`pc` lies to the **left** of the directed line defined by coordinates `pa` and `pb`).  
 /// Returns a negative value if they occur in clockwise order (`pc` lies to the **right** of the directed line `pa, pb`).  
 /// Returns `0` if they are **collinear**.  
-pub fn orient2d<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
-    let pa = Coord {
-        x: pa.x.into(),
-        y: pa.y.into(),
-    };
-    let pb = Coord {
-        x: pb.x.into(),
-        y: pb.y.into(),
-    };
-    let pc = Coord {
-        x: pc.x.into(),
-        y: pc.y.into(),
-    };
-
+pub fn orient2d_generic<T: Ieee754Float>(
+    pa: CoordGeneric<T>,
+    pb: CoordGeneric<T>,
+    pc: CoordGeneric<T>,
+) -> T {
     let detleft = (pa.x - pc.x) * (pb.y - pc.y);
     let detright = (pa.y - pc.y) * (pb.x - pc.x);
     let det = detleft - detright;
 
-    // The errbound calculation was changed to require only one branch on the likely execution path.
-    // This improves performance on modern processors as discussed by Ozaki et al in
-    // https://doi.org/10.1007/s10543-015-0574-9
-    // The underflow guard "+ u_N" was omitted because orient2dadapt(...) would not guarantee
-    // correct results in cases of underflow, the derivation of THETA is given in the reference.
     let detsum = abs(detleft + detright);
-    const THETA: f64 = 3.3306690621773722e-16;
-    let errbound = THETA * detsum;
+    let errbound = T::CCWERRBOUND_A * detsum;
     if det >= errbound || -det >= errbound {
         det
     } else {
@@ -107,7 +188,28 @@ pub fn orient2d<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
     }
 }
 
-fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) -> f64 {
+pub fn orient2d<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>) -> f64 {
+    let pa = CoordGeneric::<f64> {
+        x: pa.x.into(),
+        y: pa.y.into(),
+    };
+    let pb = CoordGeneric::<f64> {
+        x: pb.x.into(),
+        y: pb.y.into(),
+    };
+    let pc = CoordGeneric::<f64> {
+        x: pc.x.into(),
+        y: pc.y.into(),
+    };
+    orient2d_generic::<f64>(pa, pb, pc)
+}
+
+fn orient2dadapt<T: Ieee754Float>(
+    pa: CoordGeneric<T>,
+    pb: CoordGeneric<T>,
+    pc: CoordGeneric<T>,
+    detsum: T,
+) -> T {
     let acx = pa.x - pc.x;
     let bcx = pb.x - pc.x;
     let acy = pa.y - pc.y;
@@ -120,7 +222,7 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
     let B = [B0, B1, B2, B3];
 
     let mut det = estimate(&B);
-    let errbound = CCWERRBOUND_B * detsum;
+    let errbound = T::CCWERRBOUND_B * detsum;
     if det >= errbound || (-det >= errbound) {
         return det;
     }
@@ -130,11 +232,15 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
     let acytail = two_diff_tail(pa.y, pc.y, acy);
     let bcytail = two_diff_tail(pb.y, pc.y, bcy);
 
-    if acxtail == 0.0 && acytail == 0.0 && bcxtail == 0.0 && bcytail == 0.0 {
+    if acxtail == T::from(0.0)
+        && acytail == T::from(0.0)
+        && bcxtail == T::from(0.0)
+        && bcytail == T::from(0.0)
+    {
         return det;
     }
 
-    let errbound = CCWERRBOUND_C * detsum + RESULTERRBOUND * abs(det);
+    let errbound = T::CCWERRBOUND_C * detsum + T::RESULTERRBOUND * abs(det);
     det += (acx * bcytail + bcy * acxtail) - (acy * bcxtail + bcx * acytail);
 
     if det >= errbound || -det >= errbound {
@@ -146,7 +252,7 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
     let (u3, u2, u1, u0) = two_two_diff(s1, s0, t1, t0);
     let U = [u0, u1, u2, u3];
 
-    let mut C1 = [0.0f64; 8];
+    let mut C1 = [T::from(0.0); 8];
     let c1length = fast_expansion_sum_zeroelim(&B, &U, &mut C1);
 
     let (s1, s0) = two_product(acx, bcytail);
@@ -154,14 +260,14 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
     let (u3, u2, u1, u0) = two_two_diff(s1, s0, t1, t0);
     let U = [u0, u1, u2, u3];
 
-    let mut C2 = [0.0f64; 12];
+    let mut C2 = [T::from(0.0); 12];
     let c2length = fast_expansion_sum_zeroelim(&C1[..c1length], &U, &mut C2);
 
     let (s1, s0) = two_product(acxtail, bcytail);
     let (t1, t0) = two_product(acytail, bcxtail);
     let (u3, u2, u1, u0) = two_two_diff(s1, s0, t1, t0);
     let U = [u0, u1, u2, u3];
-    let mut D = [0.0f64; 16];
+    let mut D = [T::from(0.0); 16];
     let dlength = fast_expansion_sum_zeroelim(&C2[..c2length], &U, &mut D);
     D[dlength - 1]
 }
@@ -170,33 +276,12 @@ fn orient2dadapt(pa: Coord<f64>, pb: Coord<f64>, pc: Coord<f64>, detsum: f64) ->
 /// ("below" is defined so that `pa`, `pb`, and `pc` appear in counterclockwise order when viewed from above the plane).  
 /// Returns a negative value if `pd` lies above the plane.  
 /// Returns `0` if they are **coplanar**.  
-pub fn orient3d<T: Into<f64>>(
-    pa: Coord3D<T>,
-    pb: Coord3D<T>,
-    pc: Coord3D<T>,
-    pd: Coord3D<T>,
-) -> f64 {
-    let pa = Coord3D {
-        x: pa.x.into(),
-        y: pa.y.into(),
-        z: pa.z.into(),
-    };
-    let pb = Coord3D {
-        x: pb.x.into(),
-        y: pb.y.into(),
-        z: pb.z.into(),
-    };
-    let pc = Coord3D {
-        x: pc.x.into(),
-        y: pc.y.into(),
-        z: pc.z.into(),
-    };
-    let pd = Coord3D {
-        x: pd.x.into(),
-        y: pd.y.into(),
-        z: pd.z.into(),
-    };
-
+pub fn orient3d_generic<T: Ieee754Float>(
+    pa: Coord3DGeneric<T>,
+    pb: Coord3DGeneric<T>,
+    pc: Coord3DGeneric<T>,
+    pd: Coord3DGeneric<T>,
+) -> T {
     let adx = pa.x - pd.x;
     let bdx = pb.x - pd.x;
     let cdx = pc.x - pd.x;
@@ -222,7 +307,7 @@ pub fn orient3d<T: Into<f64>>(
         + (abs(cdxady) + abs(adxcdy)) * abs(bdz)
         + (abs(adxbdy) + abs(bdxady)) * abs(cdz);
 
-    let errbound = O3DERRBOUND_A * permanent;
+    let errbound = T::O3DERRBOUND_A * permanent;
     if det > errbound || -det > errbound {
         return det;
     }
@@ -230,13 +315,42 @@ pub fn orient3d<T: Into<f64>>(
     orient3dadapt(pa, pb, pc, pd, permanent)
 }
 
-fn orient3dadapt(
-    pa: Coord3D<f64>,
-    pb: Coord3D<f64>,
-    pc: Coord3D<f64>,
-    pd: Coord3D<f64>,
-    permanent: f64,
+pub fn orient3d<T: Into<f64>>(
+    pa: Coord3D<T>,
+    pb: Coord3D<T>,
+    pc: Coord3D<T>,
+    pd: Coord3D<T>,
 ) -> f64 {
+    let pa = Coord3DGeneric::<f64> {
+        x: pa.x.into(),
+        y: pa.y.into(),
+        z: pa.z.into(),
+    };
+    let pb = Coord3DGeneric::<f64> {
+        x: pb.x.into(),
+        y: pb.y.into(),
+        z: pb.z.into(),
+    };
+    let pc = Coord3DGeneric::<f64> {
+        x: pc.x.into(),
+        y: pc.y.into(),
+        z: pc.z.into(),
+    };
+    let pd = Coord3DGeneric::<f64> {
+        x: pd.x.into(),
+        y: pd.y.into(),
+        z: pd.z.into(),
+    };
+    orient3d_generic(pa, pb, pc, pd)
+}
+
+fn orient3dadapt<T: Ieee754Float>(
+    pa: Coord3DGeneric<T>,
+    pb: Coord3DGeneric<T>,
+    pc: Coord3DGeneric<T>,
+    pd: Coord3DGeneric<T>,
+    permanent: T,
+) -> T {
     let adx = pa.x - pd.x;
     let bdx = pb.x - pd.x;
     let cdx = pc.x - pd.x;
@@ -251,30 +365,30 @@ fn orient3dadapt(
     let (cdxbdy1, cdxbdy0) = two_product(cdx, bdy);
     let (bc3, bc2, bc1, bc0) = two_two_diff(bdxcdy1, bdxcdy0, cdxbdy1, cdxbdy0);
     let bc = [bc0, bc1, bc2, bc3];
-    let mut adet = [0f64; 8];
+    let mut adet = [T::from(0.0); 8];
     let alen = scale_expansion_zeroelim(&bc[..4], adz, &mut adet);
 
     let (cdxady1, cdxady0) = two_product(cdx, ady);
     let (adxcdy1, adxcdy0) = two_product(adx, cdy);
     let (ca3, ca2, ca1, ca0) = two_two_diff(cdxady1, cdxady0, adxcdy1, adxcdy0);
     let ca = [ca0, ca1, ca2, ca3];
-    let mut bdet = [0f64; 8];
+    let mut bdet = [T::from(0.0); 8];
     let blen = scale_expansion_zeroelim(&ca[..4], bdz, &mut bdet);
 
     let (adxbdy1, adxbdy0) = two_product(adx, bdy);
     let (bdxady1, bdxady0) = two_product(bdx, ady);
     let (ab3, ab2, ab1, ab0) = two_two_diff(adxbdy1, adxbdy0, bdxady1, bdxady0);
     let ab = [ab0, ab1, ab2, ab3];
-    let mut cdet = [0f64; 8];
+    let mut cdet = [T::from(0.0); 8];
     let clen = scale_expansion_zeroelim(&ab[..4], cdz, &mut cdet);
 
-    let mut abdet = [0f64; 16];
+    let mut abdet = [T::from(0.0); 16];
     let ablen = fast_expansion_sum_zeroelim(&adet[..alen], &bdet[..blen], &mut abdet);
-    let mut fin1 = [0f64; 192];
+    let mut fin1 = [T::from(0.0); 192];
     let finlength = fast_expansion_sum_zeroelim(&abdet[..ablen], &cdet[..clen], &mut fin1);
 
     let mut det = estimate(&fin1[..finlength]);
-    let mut errbound = O3DERRBOUND_B * permanent;
+    let mut errbound = T::O3DERRBOUND_B * permanent;
     if det >= errbound || -det >= errbound {
         return det;
     }
@@ -289,20 +403,20 @@ fn orient3dadapt(
     let bdztail = two_diff_tail(pb.z, pd.z, bdz);
     let cdztail = two_diff_tail(pc.z, pd.z, cdz);
 
-    if (adxtail == 0.0)
-        && (bdxtail == 0.0)
-        && (cdxtail == 0.0)
-        && (adytail == 0.0)
-        && (bdytail == 0.0)
-        && (cdytail == 0.0)
-        && (adztail == 0.0)
-        && (bdztail == 0.0)
-        && (cdztail == 0.0)
+    if (adxtail == T::from(0.0))
+        && (bdxtail == T::from(0.0))
+        && (cdxtail == T::from(0.0))
+        && (adytail == T::from(0.0))
+        && (bdytail == T::from(0.0))
+        && (cdytail == T::from(0.0))
+        && (adztail == T::from(0.0))
+        && (bdztail == T::from(0.0))
+        && (cdztail == T::from(0.0))
     {
         return det;
     }
 
-    errbound = O3DERRBOUND_C * permanent + RESULTERRBOUND * abs(det);
+    errbound = T::O3DERRBOUND_C * permanent + T::RESULTERRBOUND * abs(det);
     det += (adz * ((bdx * cdytail + cdy * bdxtail) - (bdy * cdxtail + cdx * bdytail))
         + adztail * (bdx * cdy - bdy * cdx))
         + (bdz * ((cdx * adytail + ady * cdxtail) - (cdy * adxtail + adx * cdytail))
@@ -314,25 +428,25 @@ fn orient3dadapt(
     }
 
     let mut finnow = fin1;
-    let mut finother = [0f64; 192];
+    let mut finother = [T::from(0.0); 192];
 
-    let mut at_b = [0f64; 4];
-    let mut at_c = [0f64; 4];
-    let mut bt_c = [0f64; 4];
-    let mut bt_a = [0f64; 4];
-    let mut ct_a = [0f64; 4];
-    let mut ct_b = [0f64; 4];
+    let mut at_b = [T::from(0.0); 4];
+    let mut at_c = [T::from(0.0); 4];
+    let mut bt_c = [T::from(0.0); 4];
+    let mut bt_a = [T::from(0.0); 4];
+    let mut ct_a = [T::from(0.0); 4];
+    let mut ct_b = [T::from(0.0); 4];
     let at_blen: usize;
     let at_clen: usize;
     let bt_clen: usize;
     let bt_alen: usize;
     let ct_alen: usize;
     let ct_blen: usize;
-    if adxtail == 0.0 {
-        if adytail == 0.0 {
-            at_b[0] = 0.0;
+    if adxtail == T::from(0.0) {
+        if adytail == T::from(0.0) {
+            at_b[0] = 0.into();
             at_blen = 1;
-            at_c[0] = 0.0;
+            at_c[0] = 0.into();
             at_clen = 1;
         } else {
             let negate = -adytail;
@@ -341,7 +455,7 @@ fn orient3dadapt(
             (at_c[1], at_c[0]) = two_product(adytail, cdx);
             at_clen = 2;
         }
-    } else if adytail == 0.0 {
+    } else if adytail == T::from(0.0) {
         (at_b[1], at_b[0]) = two_product(adxtail, bdy);
         at_blen = 2;
         let negate = -adxtail;
@@ -359,11 +473,11 @@ fn orient3dadapt(
             two_two_diff(adyt_cdx1, adyt_cdx0, adxt_cdy1, adxt_cdy0);
         at_clen = 4;
     }
-    if bdxtail == 0.0 {
-        if bdytail == 0.0 {
-            bt_c[0] = 0.0;
+    if bdxtail == T::from(0.0) {
+        if bdytail == T::from(0.0) {
+            bt_c[0] = 0.into();
             bt_clen = 1;
-            bt_a[0] = 0.0;
+            bt_a[0] = 0.into();
             bt_alen = 1;
         } else {
             let negate = -bdytail;
@@ -372,7 +486,7 @@ fn orient3dadapt(
             (bt_a[1], bt_a[0]) = two_product(bdytail, adx);
             bt_alen = 2;
         }
-    } else if bdytail == 0.0 {
+    } else if bdytail == T::from(0.0) {
         (bt_c[1], bt_c[0]) = two_product(bdxtail, cdy);
         bt_clen = 2;
         let negate = -bdxtail;
@@ -390,11 +504,11 @@ fn orient3dadapt(
             two_two_diff(bdyt_adx1, bdyt_adx0, bdxt_ady1, bdxt_ady0);
         bt_alen = 4;
     }
-    if cdxtail == 0.0 {
-        if cdytail == 0.0 {
-            ct_a[0] = 0.0;
+    if cdxtail == T::from(0.0) {
+        if cdytail == T::from(0.0) {
+            ct_a[0] = 0.into();
             ct_alen = 1;
-            ct_b[0] = 0.0;
+            ct_b[0] = 0.into();
             ct_blen = 1;
         } else {
             let negate = -cdytail;
@@ -403,7 +517,7 @@ fn orient3dadapt(
             (ct_b[1], ct_b[0]) = two_product(cdytail, bdx);
             ct_blen = 2;
         }
-    } else if cdytail == 0.0 {
+    } else if cdytail == T::from(0.0) {
         (ct_a[1], ct_a[0]) = two_product(cdxtail, ady);
         ct_alen = 2;
         let negate = -cdxtail;
@@ -422,12 +536,12 @@ fn orient3dadapt(
         ct_blen = 4;
     }
 
-    let mut bct = [0f64; 8];
-    let mut cat = [0f64; 8];
-    let mut abt = [0f64; 8];
-    let mut u = [0f64; 4];
-    let mut v = [0f64; 12];
-    let mut w = [0f64; 16];
+    let mut bct = [T::from(0.0); 8];
+    let mut cat = [T::from(0.0); 8];
+    let mut abt = [T::from(0.0); 8];
+    let mut u = [T::from(0.0); 4];
+    let mut v = [T::from(0.0); 12];
+    let mut w = [T::from(0.0); 16];
     let mut vlength: usize;
     let mut wlength: usize;
 
@@ -447,42 +561,42 @@ fn orient3dadapt(
     finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &w[..wlength], &mut finother);
     ::core::mem::swap(&mut finnow, &mut finother);
 
-    if adztail != 0.0 {
+    if adztail != T::from(0.0) {
         vlength = scale_expansion_zeroelim(&bc[..4], adztail, &mut v);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &v[..vlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
     }
-    if bdztail != 0.0 {
+    if bdztail != T::from(0.0) {
         vlength = scale_expansion_zeroelim(&ca[..4], bdztail, &mut v);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &v[..vlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
     }
-    if cdztail != 0.0 {
+    if cdztail != T::from(0.0) {
         vlength = scale_expansion_zeroelim(&ab[..4], cdztail, &mut v);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &v[..vlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
     }
 
-    if adxtail != 0.0 {
-        if bdytail != 0.0 {
+    if adxtail != T::from(0.0) {
+        if bdytail != T::from(0.0) {
             let (adxt_bdyt1, adxt_bdyt0) = two_product(adxtail, bdytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(adxt_bdyt1, adxt_bdyt0, cdz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if cdztail != 0.0 {
+            if cdztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(adxt_bdyt1, adxt_bdyt0, cdztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
                 ::core::mem::swap(&mut finnow, &mut finother);
             }
         }
-        if cdytail != 0.0 {
+        if cdytail != T::from(0.0) {
             let negate = -adxtail;
             let (adxt_cdyt1, adxt_cdyt0) = two_product(negate, cdytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(adxt_cdyt1, adxt_cdyt0, bdz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if bdztail != 0.0 {
+            if bdztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(adxt_cdyt1, adxt_cdyt0, bdztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
@@ -490,26 +604,26 @@ fn orient3dadapt(
             }
         }
     }
-    if bdxtail != 0.0 {
-        if cdytail != 0.0 {
+    if bdxtail != T::from(0.0) {
+        if cdytail != T::from(0.0) {
             let (bdxt_cdyt1, bdxt_cdyt0) = two_product(bdxtail, cdytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(bdxt_cdyt1, bdxt_cdyt0, adz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if adztail != 0.0 {
+            if adztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(bdxt_cdyt1, bdxt_cdyt0, adztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
                 ::core::mem::swap(&mut finnow, &mut finother);
             }
         }
-        if adytail != 0.0 {
+        if adytail != T::from(0.0) {
             let negate = -bdxtail;
             let (bdxt_adyt1, bdxt_adyt0) = two_product(negate, adytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(bdxt_adyt1, bdxt_adyt0, cdz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if cdztail != 0.0 {
+            if cdztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(bdxt_adyt1, bdxt_adyt0, cdztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
@@ -517,26 +631,26 @@ fn orient3dadapt(
             }
         }
     }
-    if cdxtail != 0.0 {
-        if adytail != 0.0 {
+    if cdxtail != T::from(0.0) {
+        if adytail != T::from(0.0) {
             let (cdxt_adyt1, cdxt_adyt0) = two_product(cdxtail, adytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(cdxt_adyt1, cdxt_adyt0, bdz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if bdztail != 0.0 {
+            if bdztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(cdxt_adyt1, cdxt_adyt0, bdztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
                 ::core::mem::swap(&mut finnow, &mut finother);
             }
         }
-        if bdytail != 0.0 {
+        if bdytail != T::from(0.0) {
             let negate = -cdxtail;
             let (cdxt_bdyt1, cdxt_bdyt0) = two_product(negate, bdytail);
             (u[3], u[2], u[1], u[0]) = two_one_product(cdxt_bdyt1, cdxt_bdyt0, adz);
             finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
             ::core::mem::swap(&mut finnow, &mut finother);
-            if adztail != 0.0 {
+            if adztail != T::from(0.0) {
                 (u[3], u[2], u[1], u[0]) = two_one_product(cdxt_bdyt1, cdxt_bdyt0, adztail);
                 finlength =
                     fast_expansion_sum_zeroelim(&finnow[..finlength], &u[..4], &mut finother);
@@ -545,17 +659,17 @@ fn orient3dadapt(
         }
     }
 
-    if adztail != 0.0 {
+    if adztail != T::from(0.0) {
         wlength = scale_expansion_zeroelim(&bct[..bctlen], adztail, &mut w);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &w[..wlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
     }
-    if bdztail != 0.0 {
+    if bdztail != T::from(0.0) {
         wlength = scale_expansion_zeroelim(&cat[..catlen], bdztail, &mut w);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &w[..wlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
     }
-    if cdztail != 0.0 {
+    if cdztail != T::from(0.0) {
         wlength = scale_expansion_zeroelim(&abt[..abtlen], cdztail, &mut w);
         finlength = fast_expansion_sum_zeroelim(&finnow[..finlength], &w[..wlength], &mut finother);
         ::core::mem::swap(&mut finnow, &mut finother);
@@ -568,24 +682,12 @@ fn orient3dadapt(
 /// Returns a negative value if it lies **outside** the circle.  
 /// Returns `0` if the four points are **cocircular**.  
 /// **Note**: The points `pa`, `pb`, and `pc` must be in **counterclockwise order**, or the sign of the result will be reversed.
-pub fn incircle<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>) -> f64 {
-    let pa = Coord {
-        x: pa.x.into(),
-        y: pa.y.into(),
-    };
-    let pb = Coord {
-        x: pb.x.into(),
-        y: pb.y.into(),
-    };
-    let pc = Coord {
-        x: pc.x.into(),
-        y: pc.y.into(),
-    };
-    let pd = Coord {
-        x: pd.x.into(),
-        y: pd.y.into(),
-    };
-
+pub fn incircle_generic<T: Ieee754Float>(
+    pa: CoordGeneric<T>,
+    pb: CoordGeneric<T>,
+    pc: CoordGeneric<T>,
+    pd: CoordGeneric<T>,
+) -> T {
     let adx = pa.x - pd.x;
     let bdx = pb.x - pd.x;
     let cdx = pc.x - pd.x;
@@ -610,28 +712,48 @@ pub fn incircle<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coor
     let permanent = (abs(bdxcdy) + abs(cdxbdy)) * alift
         + (abs(cdxady) + abs(adxcdy)) * blift
         + (abs(adxbdy) + abs(bdxady)) * clift;
-    let errbound = ICCERRBOUND_A * permanent;
+    let errbound = T::ICCERRBOUND_A * permanent;
     if det > errbound || -det > errbound {
         return det;
     }
     incircleadapt(pa, pb, pc, pd, permanent)
 }
 
-fn incircleadapt(
-    pa: Coord<f64>,
-    pb: Coord<f64>,
-    pc: Coord<f64>,
-    pd: Coord<f64>,
-    permanent: f64,
-) -> f64 {
-    let mut temp8 = [0f64; 8];
-    let mut temp16a = [0f64; 16];
-    let mut temp16b = [0f64; 16];
-    let mut temp16c = [0f64; 16];
-    let mut temp32a = [0f64; 32];
-    let mut temp32b = [0f64; 32];
-    let mut temp48 = [0f64; 48];
-    let mut temp64 = [0f64; 64];
+pub fn incircle<T: Into<f64>>(pa: Coord<T>, pb: Coord<T>, pc: Coord<T>, pd: Coord<T>) -> f64 {
+    let pa = CoordGeneric::<f64> {
+        x: pa.x.into(),
+        y: pa.y.into(),
+    };
+    let pb = CoordGeneric::<f64> {
+        x: pb.x.into(),
+        y: pb.y.into(),
+    };
+    let pc = CoordGeneric::<f64> {
+        x: pc.x.into(),
+        y: pc.y.into(),
+    };
+    let pd = CoordGeneric::<f64> {
+        x: pd.x.into(),
+        y: pd.y.into(),
+    };
+    incircle_generic(pa, pb, pc, pd)
+}
+
+fn incircleadapt<T: Ieee754Float>(
+    pa: CoordGeneric<T>,
+    pb: CoordGeneric<T>,
+    pc: CoordGeneric<T>,
+    pd: CoordGeneric<T>,
+    permanent: T,
+) -> T {
+    let mut temp8 = [T::from(0.0); 8];
+    let mut temp16a = [T::from(0.0); 16];
+    let mut temp16b = [T::from(0.0); 16];
+    let mut temp16c = [T::from(0.0); 16];
+    let mut temp32a = [T::from(0.0); 32];
+    let mut temp32b = [T::from(0.0); 32];
+    let mut temp48 = [T::from(0.0); 48];
+    let mut temp64 = [T::from(0.0); 64];
 
     let adx = pa.x - pd.x;
     let bdx = pb.x - pd.x;
@@ -645,15 +767,15 @@ fn incircleadapt(
     let (bc3, bc2, bc1, bc0) = two_two_diff(bdxcdy1, bdxcdy0, cdxbdy1, cdxbdy0);
     let bc = [bc0, bc1, bc2, bc3];
 
-    let mut axbc = [0f64; 8];
+    let mut axbc = [T::from(0.0); 8];
     let axbclen = scale_expansion_zeroelim(&bc, adx, &mut axbc);
-    let mut axxbc = [0f64; 16];
+    let mut axxbc = [T::from(0.0); 16];
     let axxbclen = scale_expansion_zeroelim(&axbc[..axbclen], adx, &mut axxbc);
-    let mut aybc = [0f64; 8];
+    let mut aybc = [T::from(0.0); 8];
     let aybclen = scale_expansion_zeroelim(&bc, ady, &mut aybc);
-    let mut ayybc = [0f64; 16];
+    let mut ayybc = [T::from(0.0); 16];
     let ayybclen = scale_expansion_zeroelim(&aybc[..aybclen], ady, &mut ayybc);
-    let mut adet = [0f64; 32];
+    let mut adet = [T::from(0.0); 32];
     let alen = fast_expansion_sum_zeroelim(&axxbc[0..axxbclen], &ayybc[0..ayybclen], &mut adet);
 
     let (cdxady1, cdxady0) = two_product(cdx, ady);
@@ -661,15 +783,15 @@ fn incircleadapt(
     let (c3, c2, c1, c0) = two_two_diff(cdxady1, cdxady0, adxcdy1, adxcdy0);
     let ca = [c0, c1, c2, c3];
 
-    let mut bxca = [0f64; 8];
+    let mut bxca = [T::from(0.0); 8];
     let bxcalen = scale_expansion_zeroelim(&ca, bdx, &mut bxca);
-    let mut bxxca = [0f64; 16];
+    let mut bxxca = [T::from(0.0); 16];
     let bxxcalen = scale_expansion_zeroelim(&bxca[..bxcalen], bdx, &mut bxxca);
-    let mut byca = [0f64; 8];
+    let mut byca = [T::from(0.0); 8];
     let bycalen = scale_expansion_zeroelim(&ca, bdy, &mut byca);
-    let mut byyca = [0f64; 16];
+    let mut byyca = [T::from(0.0); 16];
     let byycalen = scale_expansion_zeroelim(&byca[..bycalen], bdy, &mut byyca);
-    let mut bdet = [0f64; 32];
+    let mut bdet = [T::from(0.0); 32];
     let blen = fast_expansion_sum_zeroelim(&bxxca[..bxxcalen], &byyca[0..byycalen], &mut bdet);
 
     let (adxbdy1, adxbdy0) = two_product(adx, bdy);
@@ -677,24 +799,24 @@ fn incircleadapt(
     let (ab3, ab2, ab1, ab0) = two_two_diff(adxbdy1, adxbdy0, bdxady1, bdxady0);
     let ab = [ab0, ab1, ab2, ab3];
 
-    let mut cxab = [0f64; 8];
+    let mut cxab = [T::from(0.0); 8];
     let cxablen = scale_expansion_zeroelim(&ab, cdx, &mut cxab);
-    let mut cxxab = [0f64; 16];
+    let mut cxxab = [T::from(0.0); 16];
     let cxxablen = scale_expansion_zeroelim(&cxab[..cxablen], cdx, &mut cxxab);
-    let mut cyab = [0f64; 8];
+    let mut cyab = [T::from(0.0); 8];
     let cyablen = scale_expansion_zeroelim(&ab, cdy, &mut cyab);
-    let mut cyyab = [0f64; 16];
+    let mut cyyab = [T::from(0.0); 16];
     let cyyablen = scale_expansion_zeroelim(&cyab[..cyablen], cdy, &mut cyyab);
-    let mut cdet = [0f64; 32];
+    let mut cdet = [T::from(0.0); 32];
     let clen = fast_expansion_sum_zeroelim(&cxxab[..cxxablen], &cyyab[..cyyablen], &mut cdet);
 
-    let mut abdet = [0f64; 64];
+    let mut abdet = [T::from(0.0); 64];
     let ablen = fast_expansion_sum_zeroelim(&adet[..alen], &bdet[..blen], &mut abdet);
-    let mut fin1 = [0f64; 1152];
+    let mut fin1 = [T::from(0.0); 1152];
     let mut finlength = fast_expansion_sum_zeroelim(&abdet[..ablen], &cdet[..clen], &mut fin1);
 
     let mut det = estimate(&fin1[..finlength]);
-    let errbound = ICCERRBOUND_B * permanent;
+    let errbound = T::ICCERRBOUND_B * permanent;
     if det >= errbound || -det >= errbound {
         return det;
     }
@@ -705,84 +827,104 @@ fn incircleadapt(
     let bdytail = two_diff_tail(pb.y, pd.y, bdy);
     let cdxtail = two_diff_tail(pc.x, pd.x, cdx);
     let cdytail = two_diff_tail(pc.y, pd.y, cdy);
-    if adxtail == 0.0
-        && bdxtail == 0.0
-        && cdxtail == 0.0
-        && adytail == 0.0
-        && bdytail == 0.0
-        && cdytail == 0.0
+    if adxtail == T::from(0.0)
+        && bdxtail == T::from(0.0)
+        && cdxtail == T::from(0.0)
+        && adytail == T::from(0.0)
+        && bdytail == T::from(0.0)
+        && cdytail == T::from(0.0)
     {
         return det;
     }
 
-    let errbound = ICCERRBOUND_C * permanent + RESULTERRBOUND * abs(det);
+    let errbound = T::ICCERRBOUND_C * permanent + T::RESULTERRBOUND * abs(det);
     det += ((adx * adx + ady * ady)
         * ((bdx * cdytail + cdy * bdxtail) - (bdy * cdxtail + cdx * bdytail))
-        + 2.0 * (adx * adxtail + ady * adytail) * (bdx * cdy - bdy * cdx))
+        + <i16 as Into<T>>::into(2) * (adx * adxtail + ady * adytail) * (bdx * cdy - bdy * cdx))
         + ((bdx * bdx + bdy * bdy)
             * ((cdx * adytail + ady * cdxtail) - (cdy * adxtail + adx * cdytail))
-            + 2.0 * (bdx * bdxtail + bdy * bdytail) * (cdx * ady - cdy * adx))
+            + <i16 as Into<T>>::into(2)
+                * (bdx * bdxtail + bdy * bdytail)
+                * (cdx * ady - cdy * adx))
         + ((cdx * cdx + cdy * cdy)
             * ((adx * bdytail + bdy * adxtail) - (ady * bdxtail + bdx * adytail))
-            + 2.0 * (cdx * cdxtail + cdy * cdytail) * (adx * bdy - ady * bdx));
+            + <i16 as Into<T>>::into(2)
+                * (cdx * cdxtail + cdy * cdytail)
+                * (adx * bdy - ady * bdx));
 
     if det >= errbound || -det >= errbound {
         return det;
     }
 
-    let mut fin2 = [0f64; 1152];
+    let mut fin2 = [T::from(0.0); 1152];
 
-    let aa = if bdxtail != 0.0 || bdytail != 0.0 || cdxtail != 0.0 || cdytail != 0.0 {
+    let aa = if bdxtail != T::from(0.0)
+        || bdytail != T::from(0.0)
+        || cdxtail != T::from(0.0)
+        || cdytail != T::from(0.0)
+    {
         let (adxadx1, adxadx0) = square(adx);
         let (adyady1, adyady0) = square(ady);
         let (aa3, aa2, aa1, aa0) = two_two_sum(adxadx1, adxadx0, adyady1, adyady0);
         [aa0, aa1, aa2, aa3]
     } else {
-        [0f64; 4]
+        [T::from(0.0); 4]
     };
 
-    let bb = if cdxtail != 0.0 || cdytail != 0.0 || adxtail != 0.0 || adytail != 0.0 {
+    let bb = if cdxtail != T::from(0.0)
+        || cdytail != T::from(0.0)
+        || adxtail != T::from(0.0)
+        || adytail != T::from(0.0)
+    {
         let (bdxbdx1, bdxbdx0) = square(bdx);
         let (bdybdy1, bdybdy0) = square(bdy);
         let (bb3, bb2, bb1, bb0) = two_two_sum(bdxbdx1, bdxbdx0, bdybdy1, bdybdy0);
         [bb0, bb1, bb2, bb3]
     } else {
-        [0f64; 4]
+        [T::from(0.0); 4]
     };
 
-    let cc = if adxtail != 0.0 || adytail != 0.0 || bdxtail != 0.0 || bdytail != 0.0 {
+    let cc = if adxtail != T::from(0.0)
+        || adytail != T::from(0.0)
+        || bdxtail != T::from(0.0)
+        || bdytail != T::from(0.0)
+    {
         let (cdxcdx1, cdxcdx0) = square(cdx);
         let (cdycdy1, cdycdy0) = square(cdy);
         let (cc3, cc2, cc1, cc0) = two_two_sum(cdxcdx1, cdxcdx0, cdycdy1, cdycdy0);
         [cc0, cc1, cc2, cc3]
     } else {
-        [0f64; 4]
+        [T::from(0.0); 4]
     };
 
     let mut axtbclen = 9;
-    let mut axtbc = [0f64; 8];
-    if adxtail != 0.0 {
+    let mut axtbc = [T::from(0.0); 8];
+    if adxtail != T::from(0.0) {
         axtbclen = scale_expansion_zeroelim(&bc, adxtail, &mut axtbc);
-        let mut temp16a = [0f64; 16];
-        let temp16alen = scale_expansion_zeroelim(&axtbc[..axtbclen], 2.0 * adx, &mut temp16a);
+        let mut temp16a = [T::from(0.0); 16];
+        let temp16alen = scale_expansion_zeroelim(
+            &axtbc[..axtbclen],
+            <i16 as Into<T>>::into(2) * adx,
+            &mut temp16a,
+        );
 
-        let mut axtcc = [0f64; 8];
+        let mut axtcc = [T::from(0.0); 8];
         let axtcclen = scale_expansion_zeroelim(&cc, adxtail, &mut axtcc);
-        let mut temp16b = [0f64; 16];
+        let mut temp16b = [T::from(0.0); 16];
         let temp16blen = scale_expansion_zeroelim(&axtcc[..axtcclen], bdy, &mut temp16b);
 
-        let mut axtbb = [0f64; 8];
+        let mut axtbb = [T::from(0.0); 8];
         let axtbblen = scale_expansion_zeroelim(&bb, adxtail, &mut axtbb);
-        let mut temp16c = [0f64; 16];
+        let mut temp16c = [T::from(0.0); 16];
         let temp16clen = scale_expansion_zeroelim(&axtbb[..axtbblen], -cdy, &mut temp16c);
 
-        let mut temp32a = [0f64; 32];
+        let mut temp32a = [T::from(0.0); 32];
         let temp32alen = fast_expansion_sum_zeroelim(
             &temp16a[..temp16alen],
             &temp16b[..temp16blen],
             &mut temp32a,
         );
-        let mut temp48 = [0f64; 48];
+        let mut temp48 = [T::from(0.0); 48];
         let temp48len = fast_expansion_sum_zeroelim(
             &temp16c[..temp16clen],
             &temp32a[..temp32alen],
@@ -794,16 +936,20 @@ fn incircleadapt(
     }
 
     let mut aytbclen = 9;
-    let mut aytbc = [0f64; 8];
-    if adytail != 0.0 {
+    let mut aytbc = [T::from(0.0); 8];
+    if adytail != T::from(0.0) {
         aytbclen = scale_expansion_zeroelim(&bc, adytail, &mut aytbc);
-        let temp16alen = scale_expansion_zeroelim(&aytbc[..aytbclen], 2.0 * ady, &mut temp16a);
+        let temp16alen = scale_expansion_zeroelim(
+            &aytbc[..aytbclen],
+            <i16 as Into<T>>::into(2) * ady,
+            &mut temp16a,
+        );
 
-        let mut aytbb = [0f64; 8];
+        let mut aytbb = [T::from(0.0); 8];
         let aytbblen = scale_expansion_zeroelim(&bb, adytail, &mut aytbb);
         let temp16blen = scale_expansion_zeroelim(&aytbb[..aytbblen], cdx, &mut temp16b);
 
-        let mut aytcc = [0f64; 8];
+        let mut aytcc = [T::from(0.0); 8];
         let aytcclen = scale_expansion_zeroelim(&cc, adytail, &mut aytcc);
         let temp16clen = scale_expansion_zeroelim(&aytcc[..aytcclen], -bdx, &mut temp16c);
 
@@ -824,16 +970,20 @@ fn incircleadapt(
     }
 
     let mut bxtcalen = 9;
-    let mut bxtca = [0f64; 8];
-    if bdxtail != 0.0 {
+    let mut bxtca = [T::from(0.0); 8];
+    if bdxtail != T::from(0.0) {
         bxtcalen = scale_expansion_zeroelim(&ca, bdxtail, &mut bxtca);
-        let temp16alen = scale_expansion_zeroelim(&bxtca[..bxtcalen], 2.0 * bdx, &mut temp16a);
+        let temp16alen = scale_expansion_zeroelim(
+            &bxtca[..bxtcalen],
+            <i16 as Into<T>>::into(2) * bdx,
+            &mut temp16a,
+        );
 
-        let mut bxtaa = [0f64; 8];
+        let mut bxtaa = [T::from(0.0); 8];
         let bxtaalen = scale_expansion_zeroelim(&aa, bdxtail, &mut bxtaa);
         let temp16blen = scale_expansion_zeroelim(&bxtaa[..bxtaalen], cdy, &mut temp16b);
 
-        let mut bxtcc = [0f64; 8];
+        let mut bxtcc = [T::from(0.0); 8];
         let bxtcclen = scale_expansion_zeroelim(&cc, bdxtail, &mut bxtcc);
         let temp16clen = scale_expansion_zeroelim(&bxtcc[..bxtcclen], -ady, &mut temp16c);
 
@@ -853,16 +1003,20 @@ fn incircleadapt(
     }
 
     let mut bytcalen = 9;
-    let mut bytca = [0f64; 8];
-    if bdytail != 0.0 {
+    let mut bytca = [T::from(0.0); 8];
+    if bdytail != T::from(0.0) {
         bytcalen = scale_expansion_zeroelim(&ca, bdytail, &mut bytca);
-        let temp16alen = scale_expansion_zeroelim(&bytca[..bytcalen], 2.0 * bdy, &mut temp16a);
+        let temp16alen = scale_expansion_zeroelim(
+            &bytca[..bytcalen],
+            <i16 as Into<T>>::into(2) * bdy,
+            &mut temp16a,
+        );
 
-        let mut bytcc = [0f64; 8];
+        let mut bytcc = [T::from(0.0); 8];
         let bytcclen = scale_expansion_zeroelim(&cc, bdytail, &mut bytcc);
         let temp16blen = scale_expansion_zeroelim(&bytcc[..bytcclen], adx, &mut temp16b);
 
-        let mut bytaa = [0f64; 8];
+        let mut bytaa = [T::from(0.0); 8];
         let bytaalen = scale_expansion_zeroelim(&aa, bdytail, &mut bytaa);
         let temp16clen = scale_expansion_zeroelim(&bytaa[..bytaalen], -cdx, &mut temp16c);
 
@@ -882,17 +1036,21 @@ fn incircleadapt(
         ::core::mem::swap(&mut fin1, &mut fin2)
     }
 
-    let mut cxtab = [0f64; 8];
+    let mut cxtab = [T::from(0.0); 8];
     let mut cxtablen = 9;
-    if cdxtail != 0.0 {
+    if cdxtail != T::from(0.0) {
         cxtablen = scale_expansion_zeroelim(&ab, cdxtail, &mut cxtab);
-        let temp16alen = scale_expansion_zeroelim(&cxtab[..cxtablen], 2.0 * cdx, &mut temp16a);
+        let temp16alen = scale_expansion_zeroelim(
+            &cxtab[..cxtablen],
+            <i16 as Into<T>>::into(2) * cdx,
+            &mut temp16a,
+        );
 
-        let mut cxtbb = [0f64; 8];
+        let mut cxtbb = [T::from(0.0); 8];
         let cxtbblen = scale_expansion_zeroelim(&bb, cdxtail, &mut cxtbb);
         let temp16blen = scale_expansion_zeroelim(&cxtbb[..cxtbblen], ady, &mut temp16b);
 
-        let mut cxtaa = [0f64; 8];
+        let mut cxtaa = [T::from(0.0); 8];
         let cxtaalen = scale_expansion_zeroelim(&aa, cdxtail, &mut cxtaa);
         let temp16clen = scale_expansion_zeroelim(&cxtaa[..cxtaalen], -bdy, &mut temp16c);
 
@@ -911,17 +1069,21 @@ fn incircleadapt(
         ::core::mem::swap(&mut fin1, &mut fin2);
     }
 
-    let mut cytab = [0f64; 8];
+    let mut cytab = [T::from(0.0); 8];
     let mut cytablen = 9;
-    if cdytail != 0.0 {
+    if cdytail != T::from(0.0) {
         cytablen = scale_expansion_zeroelim(&ab, cdytail, &mut cytab);
-        let temp16alen = scale_expansion_zeroelim(&cytab[..cytablen], 2.0 * cdy, &mut temp16a);
+        let temp16alen = scale_expansion_zeroelim(
+            &cytab[..cytablen],
+            <i16 as Into<T>>::into(2) * cdy,
+            &mut temp16a,
+        );
 
-        let mut cytaa = [0f64; 8];
+        let mut cytaa = [T::from(0.0); 8];
         let cytaalen = scale_expansion_zeroelim(&aa, cdytail, &mut cytaa);
         let temp16blen = scale_expansion_zeroelim(&cytaa[..cytaalen], bdx, &mut temp16b);
 
-        let mut cytbb = [0f64; 8];
+        let mut cytbb = [T::from(0.0); 8];
         let cytbblen = scale_expansion_zeroelim(&bb, cdytail, &mut cytbb);
         let temp16clen = scale_expansion_zeroelim(&cytbb[..cytbblen], -adx, &mut temp16c);
 
@@ -940,12 +1102,16 @@ fn incircleadapt(
         ::core::mem::swap(&mut fin1, &mut fin2);
     }
 
-    if adxtail != 0.0 || adytail != 0.0 {
-        let mut bctt = [0f64; 4];
-        let mut bct = [0f64; 8];
+    if adxtail != T::from(0.0) || adytail != T::from(0.0) {
+        let mut bctt = [T::from(0.0); 4];
+        let mut bct = [T::from(0.0); 8];
         let bcttlen;
         let bctlen;
-        if bdxtail != 0.0 || bdytail != 0.0 || cdxtail != 0.0 || cdytail != 0.0 {
+        if bdxtail != T::from(0.0)
+            || bdytail != T::from(0.0)
+            || cdxtail != T::from(0.0)
+            || cdytail != T::from(0.0)
+        {
             let (ti1, ti0) = two_product(bdxtail, cdy);
             let (tj1, tj0) = two_product(bdx, cdytail);
             let (u3, u2, u1, u0) = two_two_sum(ti1, ti0, tj1, tj0);
@@ -963,18 +1129,21 @@ fn incircleadapt(
             bctt = [bctt0, bctt1, bctt2, bctt3];
             bcttlen = 4;
         } else {
-            bct[0] = 0.0;
+            bct[0] = 0.into();
             bctlen = 1;
-            bctt[0] = 0.0;
+            bctt[0] = 0.into();
             bcttlen = 1;
         }
 
-        if adxtail != 0.0 {
+        if adxtail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&axtbc[..axtbclen], adxtail, &mut temp16a);
-            let mut axtbct = [0f64; 16];
+            let mut axtbct = [T::from(0.0); 16];
             let axtbctlen = scale_expansion_zeroelim(&bct[..bctlen], adxtail, &mut axtbct);
-            let temp32alen =
-                scale_expansion_zeroelim(&axtbct[..axtbctlen], 2.0 * adx, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &axtbct[..axtbctlen],
+                <i16 as Into<T>>::into(2) * adx,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -984,7 +1153,7 @@ fn incircleadapt(
                 fast_expansion_sum_zeroelim(&fin1[..finlength], &temp48[..temp48len], &mut fin2);
             ::core::mem::swap(&mut fin1, &mut fin2);
 
-            if bdytail != 0.0 {
+            if bdytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&cc, adxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], bdytail, &mut temp16a);
@@ -995,7 +1164,7 @@ fn incircleadapt(
                 );
                 ::core::mem::swap(&mut fin1, &mut fin2);
             }
-            if cdytail != 0.0 {
+            if cdytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&bb, -adxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], cdytail, &mut temp16a);
@@ -1008,10 +1177,13 @@ fn incircleadapt(
             }
 
             let temp32alen = scale_expansion_zeroelim(&axtbct[..axtbctlen], adxtail, &mut temp32a);
-            let mut axtbctt = [0f64; 8];
+            let mut axtbctt = [T::from(0.0); 8];
             let axtbcttlen = scale_expansion_zeroelim(&bctt[..bcttlen], adxtail, &mut axtbctt);
-            let temp16alen =
-                scale_expansion_zeroelim(&axtbctt[..axtbcttlen], 2.0 * adx, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &axtbctt[..axtbcttlen],
+                <i16 as Into<T>>::into(2) * adx,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&axtbctt[..axtbcttlen], adxtail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1029,12 +1201,15 @@ fn incircleadapt(
             ::core::mem::swap(&mut fin1, &mut fin2);
         }
 
-        if adytail != 0.0 {
+        if adytail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&aytbc[..aytbclen], adytail, &mut temp16a);
-            let mut aytbct = [0f64; 16];
+            let mut aytbct = [T::from(0.0); 16];
             let aytbctlen = scale_expansion_zeroelim(&bct[..bctlen], adytail, &mut aytbct);
-            let temp32alen =
-                scale_expansion_zeroelim(&aytbct[..aytbctlen], 2.0 * ady, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &aytbct[..aytbctlen],
+                <i16 as Into<T>>::into(2) * ady,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -1045,10 +1220,13 @@ fn incircleadapt(
             ::core::mem::swap(&mut fin1, &mut fin2);
 
             let temp32alen = scale_expansion_zeroelim(&aytbct[..aytbctlen], adytail, &mut temp32a);
-            let mut aytbctt = [0f64; 8];
+            let mut aytbctt = [T::from(0.0); 8];
             let aytbcttlen = scale_expansion_zeroelim(&bctt[..bcttlen], adytail, &mut aytbctt);
-            let temp16alen =
-                scale_expansion_zeroelim(&aytbctt[..aytbcttlen], 2.0 * ady, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &aytbctt[..aytbcttlen],
+                <i16 as Into<T>>::into(2) * ady,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&aytbctt[..aytbcttlen], adytail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1067,13 +1245,17 @@ fn incircleadapt(
         }
     }
 
-    if bdxtail != 0.0 || bdytail != 0.0 {
-        let mut catt = [0f64; 4];
-        let mut cat = [0f64; 8];
+    if bdxtail != T::from(0.0) || bdytail != T::from(0.0) {
+        let mut catt = [T::from(0.0); 4];
+        let mut cat = [T::from(0.0); 8];
         let cattlen;
         let catlen;
 
-        if cdxtail != 0.0 || cdytail != 0.0 || adxtail != 0.0 || adytail != 0.0 {
+        if cdxtail != T::from(0.0)
+            || cdytail != T::from(0.0)
+            || adxtail != T::from(0.0)
+            || adytail != T::from(0.0)
+        {
             let (ti1, ti0) = two_product(cdxtail, ady);
             let (tj1, tj0) = two_product(cdx, adytail);
             let (u3, u2, u1, u0) = two_two_sum(ti1, ti0, tj1, tj0);
@@ -1092,18 +1274,21 @@ fn incircleadapt(
             catt = [catt0, catt1, catt2, catt3];
             cattlen = 4;
         } else {
-            cat[0] = 0.0;
+            cat[0] = T::from(0.0);
             catlen = 1;
-            catt[0] = 0.0;
+            catt[0] = T::from(0.0);
             cattlen = 1;
         }
 
-        if bdxtail != 0.0 {
+        if bdxtail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&bxtca[..bxtcalen], bdxtail, &mut temp16a);
-            let mut bxtcat = [0f64; 16];
+            let mut bxtcat = [T::from(0.0); 16];
             let bxtcatlen = scale_expansion_zeroelim(&cat[..catlen], bdxtail, &mut bxtcat);
-            let temp32alen =
-                scale_expansion_zeroelim(&bxtcat[..bxtcatlen], 2.0 * bdx, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &bxtcat[..bxtcatlen],
+                <i16 as Into<T>>::into(2) * bdx,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -1113,7 +1298,7 @@ fn incircleadapt(
                 fast_expansion_sum_zeroelim(&fin1[..finlength], &temp48[..temp48len], &mut fin2);
             ::core::mem::swap(&mut fin1, &mut fin2);
 
-            if cdytail != 0.0 {
+            if cdytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&aa, bdxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], cdytail, &mut temp16a);
@@ -1124,7 +1309,7 @@ fn incircleadapt(
                 );
                 ::core::mem::swap(&mut fin1, &mut fin2);
             }
-            if adytail != 0.0 {
+            if adytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&cc, -bdxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], adytail, &mut temp16a);
@@ -1137,10 +1322,13 @@ fn incircleadapt(
             }
 
             let temp32alen = scale_expansion_zeroelim(&bxtcat[..bxtcatlen], bdxtail, &mut temp32a);
-            let mut bxtcatt = [0f64; 8];
+            let mut bxtcatt = [T::from(0.0); 8];
             let bxtcattlen = scale_expansion_zeroelim(&catt[..cattlen], bdxtail, &mut bxtcatt);
-            let temp16alen =
-                scale_expansion_zeroelim(&bxtcatt[..bxtcattlen], 2.0 * bdx, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &bxtcatt[..bxtcattlen],
+                <i16 as Into<T>>::into(2) * bdx,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&bxtcatt[..bxtcattlen], bdxtail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1157,12 +1345,15 @@ fn incircleadapt(
                 fast_expansion_sum_zeroelim(&fin1[..finlength], &temp64[..temp64len], &mut fin2);
             ::core::mem::swap(&mut fin1, &mut fin2);
         }
-        if bdytail != 0.0 {
+        if bdytail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&bytca[..bytcalen], bdytail, &mut temp16a);
-            let mut bytcat = [0f64; 16];
+            let mut bytcat = [T::from(0.0); 16];
             let bytcatlen = scale_expansion_zeroelim(&cat[..catlen], bdytail, &mut bytcat);
-            let temp32alen =
-                scale_expansion_zeroelim(&bytcat[..bytcatlen], 2.0 * bdy, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &bytcat[..bytcatlen],
+                <i16 as Into<T>>::into(2) * bdy,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -1173,10 +1364,13 @@ fn incircleadapt(
             ::core::mem::swap(&mut fin1, &mut fin2);
 
             let temp32alen = scale_expansion_zeroelim(&bytcat[..bytcatlen], bdytail, &mut temp32a);
-            let mut bytcatt = [0f64; 8];
+            let mut bytcatt = [T::from(0.0); 8];
             let bytcattlen = scale_expansion_zeroelim(&catt[..cattlen], bdytail, &mut bytcatt);
-            let temp16alen =
-                scale_expansion_zeroelim(&bytcatt[..bytcattlen], 2.0 * bdy, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &bytcatt[..bytcattlen],
+                <i16 as Into<T>>::into(2) * bdy,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&bytcatt[..bytcattlen], bdytail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1195,13 +1389,17 @@ fn incircleadapt(
         }
     }
 
-    if cdxtail != 0.0 || cdytail != 0.0 {
-        let mut abtt = [0f64; 4];
-        let mut abt = [0f64; 8];
+    if cdxtail != T::from(0.0) || cdytail != T::from(0.0) {
+        let mut abtt = [T::from(0.0); 4];
+        let mut abt = [T::from(0.0); 8];
         let abttlen;
         let abtlen;
 
-        if adxtail != 0.0 || adytail != 0.0 || bdxtail != 0.0 || bdytail != 0.0 {
+        if adxtail != T::from(0.0)
+            || adytail != T::from(0.0)
+            || bdxtail != T::from(0.0)
+            || bdytail != T::from(0.0)
+        {
             let (ti1, ti0) = two_product(adxtail, bdy);
             let (tj1, tj0) = two_product(adx, bdytail);
             let (u3, u2, u1, u0) = two_two_sum(ti1, ti0, tj1, tj0);
@@ -1220,18 +1418,21 @@ fn incircleadapt(
             abtt = [abtt0, abtt1, abtt2, abtt3];
             abttlen = 4;
         } else {
-            abt[0] = 0.0;
+            abt[0] = 0.into();
             abtlen = 1;
-            abtt[0] = 0.0;
+            abtt[0] = 0.into();
             abttlen = 1;
         }
 
-        if cdxtail != 0.0 {
+        if cdxtail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&cxtab[..cxtablen], cdxtail, &mut temp16a);
-            let mut cxtabt = [0f64; 16];
+            let mut cxtabt = [T::from(0.0); 16];
             let cxtabtlen = scale_expansion_zeroelim(&abt[..abtlen], cdxtail, &mut cxtabt);
-            let temp32alen =
-                scale_expansion_zeroelim(&cxtabt[..cxtabtlen], 2.0 * cdx, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &cxtabt[..cxtabtlen],
+                <i16 as Into<T>>::into(2) * cdx,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -1241,7 +1442,7 @@ fn incircleadapt(
                 fast_expansion_sum_zeroelim(&fin1[..finlength], &temp48[..temp48len], &mut fin2);
             ::core::mem::swap(&mut fin1, &mut fin2);
 
-            if adytail != 0.0 {
+            if adytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&bb, cdxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], adytail, &mut temp16a);
@@ -1252,7 +1453,7 @@ fn incircleadapt(
                 );
                 ::core::mem::swap(&mut fin1, &mut fin2);
             }
-            if bdytail != 0.0 {
+            if bdytail != T::from(0.0) {
                 let temp8len = scale_expansion_zeroelim(&aa, -cdxtail, &mut temp8);
                 let temp16alen =
                     scale_expansion_zeroelim(&temp8[..temp8len], bdytail, &mut temp16a);
@@ -1265,10 +1466,13 @@ fn incircleadapt(
             }
 
             let temp32alen = scale_expansion_zeroelim(&cxtabt[..cxtabtlen], cdxtail, &mut temp32a);
-            let mut cxtabtt = [0f64; 8];
+            let mut cxtabtt = [T::from(0.0); 8];
             let cxtabttlen = scale_expansion_zeroelim(&abtt[..abttlen], cdxtail, &mut cxtabtt);
-            let temp16alen =
-                scale_expansion_zeroelim(&cxtabtt[..cxtabttlen], 2.0 * cdx, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &cxtabtt[..cxtabttlen],
+                <i16 as Into<T>>::into(2) * cdx,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&cxtabtt[..cxtabttlen], cdxtail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1285,12 +1489,15 @@ fn incircleadapt(
                 fast_expansion_sum_zeroelim(&fin1[..finlength], &temp64[..temp64len], &mut fin2);
             ::core::mem::swap(&mut fin1, &mut fin2);
         }
-        if cdytail != 0.0 {
+        if cdytail != T::from(0.0) {
             let temp16alen = scale_expansion_zeroelim(&cytab[..cytablen], cdytail, &mut temp16a);
-            let mut cytabt = [0f64; 16];
+            let mut cytabt = [T::from(0.0); 16];
             let cytabtlen = scale_expansion_zeroelim(&abt[..abtlen], cdytail, &mut cytabt);
-            let temp32alen =
-                scale_expansion_zeroelim(&cytabt[..cytabtlen], 2.0 * cdy, &mut temp32a);
+            let temp32alen = scale_expansion_zeroelim(
+                &cytabt[..cytabtlen],
+                <i16 as Into<T>>::into(2) * cdy,
+                &mut temp32a,
+            );
             let temp48len = fast_expansion_sum_zeroelim(
                 &temp16a[..temp16alen],
                 &temp32a[..temp32alen],
@@ -1301,10 +1508,13 @@ fn incircleadapt(
             ::core::mem::swap(&mut fin1, &mut fin2);
 
             let temp32alen = scale_expansion_zeroelim(&cytabt[..cytabtlen], cdytail, &mut temp32a);
-            let mut cytabtt = [0f64; 8];
+            let mut cytabtt = [T::from(0.0); 8];
             let cytabttlen = scale_expansion_zeroelim(&abtt[..abttlen], cdytail, &mut cytabtt);
-            let temp16alen =
-                scale_expansion_zeroelim(&cytabtt[..cytabttlen], 2.0 * cdy, &mut temp16a);
+            let temp16alen = scale_expansion_zeroelim(
+                &cytabtt[..cytabttlen],
+                <i16 as Into<T>>::into(2) * cdy,
+                &mut temp16a,
+            );
             let temp16blen =
                 scale_expansion_zeroelim(&cytabtt[..cytabttlen], cdytail, &mut temp16b);
             let temp32blen = fast_expansion_sum_zeroelim(
@@ -1329,39 +1539,13 @@ fn incircleadapt(
 /// Returns a negative value if it lies outside.  
 /// Returns `0` if the five points are **cospherical**.  
 /// **NOTE**: The points `pa`, `pb`, `pc`, and `pd` must be ordered so that they have a positive orientation.
-pub fn insphere<T: Into<f64>>(
-    pa: Coord3D<T>,
-    pb: Coord3D<T>,
-    pc: Coord3D<T>,
-    pd: Coord3D<T>,
-    pe: Coord3D<T>,
-) -> f64 {
-    let pa = Coord3D {
-        x: pa.x.into(),
-        y: pa.y.into(),
-        z: pa.z.into(),
-    };
-    let pb = Coord3D {
-        x: pb.x.into(),
-        y: pb.y.into(),
-        z: pb.z.into(),
-    };
-    let pc = Coord3D {
-        x: pc.x.into(),
-        y: pc.y.into(),
-        z: pc.z.into(),
-    };
-    let pd = Coord3D {
-        x: pd.x.into(),
-        y: pd.y.into(),
-        z: pd.z.into(),
-    };
-    let pe = Coord3D {
-        x: pe.x.into(),
-        y: pe.y.into(),
-        z: pe.z.into(),
-    };
-
+pub fn insphere_generic<T: Ieee754Float>(
+    pa: Coord3DGeneric<T>,
+    pb: Coord3DGeneric<T>,
+    pc: Coord3DGeneric<T>,
+    pd: Coord3DGeneric<T>,
+    pe: Coord3DGeneric<T>,
+) -> T {
     let aex = pa.x - pe.x;
     let bex = pb.x - pe.x;
     let cex = pc.x - pe.x;
@@ -1439,7 +1623,7 @@ pub fn insphere<T: Into<f64>>(
             + (cexaeyplus + aexceyplus) * bezplus
             + (aexbeyplus + bexaeyplus) * cezplus)
             * dlift;
-    let errbound = ISPERRBOUND_A * permanent;
+    let errbound = T::ISPERRBOUND_A * permanent;
     if det > errbound || -det > errbound {
         return det;
     }
@@ -1447,40 +1631,49 @@ pub fn insphere<T: Into<f64>>(
     insphereadapt(pa, pb, pc, pd, pe, permanent)
 }
 
-fn insphereadapt<T: Into<f64>>(
+pub fn insphere<T: Into<f64>>(
     pa: Coord3D<T>,
     pb: Coord3D<T>,
     pc: Coord3D<T>,
     pd: Coord3D<T>,
     pe: Coord3D<T>,
-    permanent: f64,
 ) -> f64 {
-    let pa = Coord3D {
+    let pa = Coord3DGeneric::<f64> {
         x: pa.x.into(),
         y: pa.y.into(),
         z: pa.z.into(),
     };
-    let pb = Coord3D {
+    let pb = Coord3DGeneric::<f64> {
         x: pb.x.into(),
         y: pb.y.into(),
         z: pb.z.into(),
     };
-    let pc = Coord3D {
+    let pc = Coord3DGeneric::<f64> {
         x: pc.x.into(),
         y: pc.y.into(),
         z: pc.z.into(),
     };
-    let pd = Coord3D {
+    let pd = Coord3DGeneric::<f64> {
         x: pd.x.into(),
         y: pd.y.into(),
         z: pd.z.into(),
     };
-    let pe = Coord3D {
+    let pe = Coord3DGeneric::<f64> {
         x: pe.x.into(),
         y: pe.y.into(),
         z: pe.z.into(),
     };
+    insphere_generic(pa, pb, pc, pd, pe)
+}
 
+fn insphereadapt<T: Ieee754Float>(
+    pa: Coord3DGeneric<T>,
+    pb: Coord3DGeneric<T>,
+    pc: Coord3DGeneric<T>,
+    pd: Coord3DGeneric<T>,
+    pe: Coord3DGeneric<T>,
+    permanent: T,
+) -> T {
     let aex = pa.x - pe.x;
     let bex = pb.x - pe.x;
     let cex = pc.x - pe.x;
@@ -1524,23 +1717,23 @@ fn insphereadapt<T: Into<f64>>(
     let (bd3, bd2, bd1, bd0) = two_two_diff(bexdey1, bexdey0, dexbey1, dexbey0);
     let bd = [bd0, bd1, bd2, bd3];
 
-    let mut temp8a = [0f64; 8];
-    let mut temp8b = [0f64; 8];
-    let mut temp8c = [0f64; 8];
-    let mut temp16 = [0f64; 16];
-    let mut temp24 = [0f64; 24];
-    let mut temp48 = [0f64; 48];
-    let mut xdet = [0f64; 96];
-    let mut ydet = [0f64; 96];
-    let mut zdet = [0f64; 96];
-    let mut xydet = [0f64; 192];
-    let mut adet = [0f64; 288];
-    let mut bdet = [0f64; 288];
-    let mut cdet = [0f64; 288];
-    let mut ddet = [0f64; 288];
-    let mut abdet = [0f64; 576];
-    let mut cddet = [0f64; 576];
-    let mut fin1 = [0f64; 1152];
+    let mut temp8a = [T::from(0.0); 8];
+    let mut temp8b = [T::from(0.0); 8];
+    let mut temp8c = [T::from(0.0); 8];
+    let mut temp16 = [T::from(0.0); 16];
+    let mut temp24 = [T::from(0.0); 24];
+    let mut temp48 = [T::from(0.0); 48];
+    let mut xdet = [T::from(0.0); 96];
+    let mut ydet = [T::from(0.0); 96];
+    let mut zdet = [T::from(0.0); 96];
+    let mut xydet = [T::from(0.0); 192];
+    let mut adet = [T::from(0.0); 288];
+    let mut bdet = [T::from(0.0); 288];
+    let mut cdet = [T::from(0.0); 288];
+    let mut ddet = [T::from(0.0); 288];
+    let mut abdet = [T::from(0.0); 576];
+    let mut cddet = [T::from(0.0); 576];
+    let mut fin1 = [T::from(0.0); 1152];
 
     let mut temp8alen = scale_expansion_zeroelim(&cd[..4], bez, &mut temp8a);
     let mut temp8blen = scale_expansion_zeroelim(&bd[..4], -cez, &mut temp8b);
@@ -1611,7 +1804,7 @@ fn insphereadapt<T: Into<f64>>(
     let finlength = fast_expansion_sum_zeroelim(&abdet[..ablen], &cddet[..cdlen], &mut fin1);
 
     let mut det = estimate(&fin1[..finlength]);
-    let mut errbound = ISPERRBOUND_B * permanent;
+    let mut errbound = T::ISPERRBOUND_B * permanent;
     if det >= errbound || -det >= errbound {
         return det;
     }
@@ -1628,23 +1821,23 @@ fn insphereadapt<T: Into<f64>>(
     let dextail = two_diff_tail(pd.x, pe.x, dex);
     let deytail = two_diff_tail(pd.y, pe.y, dey);
     let deztail = two_diff_tail(pd.z, pe.z, dez);
-    if (aextail == 0.0)
-        && (aeytail == 0.0)
-        && (aeztail == 0.0)
-        && (bextail == 0.0)
-        && (beytail == 0.0)
-        && (beztail == 0.0)
-        && (cextail == 0.0)
-        && (ceytail == 0.0)
-        && (ceztail == 0.0)
-        && (dextail == 0.0)
-        && (deytail == 0.0)
-        && (deztail == 0.0)
+    if (aextail == T::from(0.0))
+        && (aeytail == T::from(0.0))
+        && (aeztail == T::from(0.0))
+        && (bextail == T::from(0.0))
+        && (beytail == T::from(0.0))
+        && (beztail == T::from(0.0))
+        && (cextail == T::from(0.0))
+        && (ceytail == T::from(0.0))
+        && (ceztail == T::from(0.0))
+        && (dextail == T::from(0.0))
+        && (deytail == T::from(0.0))
+        && (deztail == T::from(0.0))
     {
         return det;
     }
 
-    errbound = ISPERRBOUND_C * permanent + RESULTERRBOUND * abs(det);
+    errbound = T::ISPERRBOUND_C * permanent + T::RESULTERRBOUND * abs(det);
     let abeps = (aex * beytail + bey * aextail) - (aey * bextail + bex * aeytail);
     let bceps = (bex * ceytail + cey * bextail) - (bey * cextail + cex * beytail);
     let cdeps = (cex * deytail + dey * cextail) - (cey * dextail + dex * ceytail);
@@ -1663,7 +1856,7 @@ fn insphereadapt<T: Into<f64>>(
             + (cex * cex + cey * cey + cez * cez)
                 * ((dez * abeps + aez * bdeps + bez * daeps)
                     + (deztail * ab3 + aeztail * bd3 + beztail * da3))))
-        + 2.0
+        + <i16 as Into<T>>::into(2)
             * (((bex * bextail + bey * beytail + bez * beztail)
                 * (cez * da3 + dez * ac3 + aez * cd3)
                 + (dex * dextail + dey * deytail + dez * deztail)
@@ -1679,39 +1872,13 @@ fn insphereadapt<T: Into<f64>>(
     insphereexact(pa, pb, pc, pd, pe)
 }
 
-fn insphereexact<T: Into<f64>>(
-    pa: Coord3D<T>,
-    pb: Coord3D<T>,
-    pc: Coord3D<T>,
-    pd: Coord3D<T>,
-    pe: Coord3D<T>,
-) -> f64 {
-    let pa = Coord3D {
-        x: pa.x.into(),
-        y: pa.y.into(),
-        z: pa.z.into(),
-    };
-    let pb = Coord3D {
-        x: pb.x.into(),
-        y: pb.y.into(),
-        z: pb.z.into(),
-    };
-    let pc = Coord3D {
-        x: pc.x.into(),
-        y: pc.y.into(),
-        z: pc.z.into(),
-    };
-    let pd = Coord3D {
-        x: pd.x.into(),
-        y: pd.y.into(),
-        z: pd.z.into(),
-    };
-    let pe = Coord3D {
-        x: pe.x.into(),
-        y: pe.y.into(),
-        z: pe.z.into(),
-    };
-
+fn insphereexact<T: Ieee754Float>(
+    pa: Coord3DGeneric<T>,
+    pb: Coord3DGeneric<T>,
+    pc: Coord3DGeneric<T>,
+    pd: Coord3DGeneric<T>,
+    pe: Coord3DGeneric<T>,
+) -> T {
     let (axby1, axby0) = two_product(pa.x, pb.y);
     let (bxay1, bxay0) = two_product(pb.x, pa.y);
     let (ab3, ab2, ab1, ab0) = two_two_diff(axby1, axby0, bxay1, bxay0);
@@ -1762,47 +1929,47 @@ fn insphereexact<T: Into<f64>>(
     let (eb3, eb2, eb1, eb0) = two_two_diff(exby1, exby0, bxey1, bxey0);
     let eb = [eb0, eb1, eb2, eb3];
 
-    let mut temp8a = [0f64; 8];
-    let mut temp8b = [0f64; 8];
-    let mut temp16 = [0f64; 16];
-    let mut temp48a = [0f64; 48];
-    let mut temp48b = [0f64; 48];
+    let mut temp8a = [T::from(0.0); 8];
+    let mut temp8b = [T::from(0.0); 8];
+    let mut temp16 = [T::from(0.0); 16];
+    let mut temp48a = [T::from(0.0); 48];
+    let mut temp48b = [T::from(0.0); 48];
 
-    let mut abc = [0f64; 24];
-    let mut bcd = [0f64; 24];
-    let mut cde = [0f64; 24];
-    let mut dea = [0f64; 24];
-    let mut eab = [0f64; 24];
-    let mut abd = [0f64; 24];
-    let mut bce = [0f64; 24];
-    let mut cda = [0f64; 24];
-    let mut deb = [0f64; 24];
-    let mut eac = [0f64; 24];
+    let mut abc = [T::from(0.0); 24];
+    let mut bcd = [T::from(0.0); 24];
+    let mut cde = [T::from(0.0); 24];
+    let mut dea = [T::from(0.0); 24];
+    let mut eab = [T::from(0.0); 24];
+    let mut abd = [T::from(0.0); 24];
+    let mut bce = [T::from(0.0); 24];
+    let mut cda = [T::from(0.0); 24];
+    let mut deb = [T::from(0.0); 24];
+    let mut eac = [T::from(0.0); 24];
 
-    let mut abcd = [0f64; 96];
-    let mut bcde = [0f64; 96];
-    let mut cdea = [0f64; 96];
-    let mut deab = [0f64; 96];
-    let mut eabc = [0f64; 96];
+    let mut abcd = [T::from(0.0); 96];
+    let mut bcde = [T::from(0.0); 96];
+    let mut cdea = [T::from(0.0); 96];
+    let mut deab = [T::from(0.0); 96];
+    let mut eabc = [T::from(0.0); 96];
 
-    let mut temp192 = [0f64; 192];
-    let mut det384x = [0f64; 384];
-    let mut det384y = [0f64; 384];
-    let mut det384z = [0f64; 384];
+    let mut temp192 = [T::from(0.0); 192];
+    let mut det384x = [T::from(0.0); 384];
+    let mut det384y = [T::from(0.0); 384];
+    let mut det384z = [T::from(0.0); 384];
 
-    let mut detxy = [0f64; 768];
+    let mut detxy = [T::from(0.0); 768];
 
-    let mut adet = [0f64; 1152];
-    let mut bdet = [0f64; 1152];
-    let mut cdet = [0f64; 1152];
-    let mut ddet = [0f64; 1152];
-    let mut edet = [0f64; 1152];
+    let mut adet = [T::from(0.0); 1152];
+    let mut bdet = [T::from(0.0); 1152];
+    let mut cdet = [T::from(0.0); 1152];
+    let mut ddet = [T::from(0.0); 1152];
+    let mut edet = [T::from(0.0); 1152];
 
-    let mut abdet = [0f64; 2304];
-    let mut cddet = [0f64; 2304];
-    let mut cdedet = [0f64; 3456];
+    let mut abdet = [T::from(0.0); 2304];
+    let mut cddet = [T::from(0.0); 2304];
+    let mut cdedet = [T::from(0.0); 3456];
 
-    let mut deter = [0f64; 5760];
+    let mut deter = [T::from(0.0); 5760];
 
     let mut temp8alen = scale_expansion_zeroelim(&bc[..4], pa.z, &mut temp8a);
     let mut temp8blen = scale_expansion_zeroelim(&ac[..4], -pb.z, &mut temp8b);
@@ -1963,11 +2130,11 @@ fn insphereexact<T: Into<f64>>(
     deter[deterlen - 1]
 }
 
-fn scale_expansion_zeroelim(e: &[f64], b: f64, h: &mut [f64]) -> usize {
+fn scale_expansion_zeroelim<T: Ieee754Float>(e: &[T], b: T, h: &mut [T]) -> usize {
     let (bhi, blo) = split(b);
     let (mut Q, hh) = two_product_presplit(e[0], b, bhi, blo);
     let mut hindex = 0;
-    if hh != 0.0 {
+    if hh != T::from(0.0) {
         h[hindex] = hh;
         hindex += 1;
     }
@@ -1975,18 +2142,18 @@ fn scale_expansion_zeroelim(e: &[f64], b: f64, h: &mut [f64]) -> usize {
         let enow = e[eindex];
         let (product1, product0) = two_product_presplit(enow, b, bhi, blo);
         let (sum, hh) = two_sum(Q, product0);
-        if hh != 0.0 {
+        if hh != T::from(0.0) {
             h[hindex] = hh;
             hindex += 1;
         }
         let (new_q, hh) = fast_two_sum(product1, sum);
         Q = new_q;
-        if hh != 0.0 {
+        if hh != T::from(0.0) {
             h[hindex] = hh;
             hindex += 1;
         }
     }
-    if Q != 0.0 || hindex == 0 {
+    if Q != T::from(0.0) || hindex == 0 {
         h[hindex] = Q;
         hindex += 1;
     }
@@ -1994,13 +2161,13 @@ fn scale_expansion_zeroelim(e: &[f64], b: f64, h: &mut [f64]) -> usize {
 }
 
 #[inline]
-fn two_product(a: f64, b: f64) -> (f64, f64) {
+fn two_product<T: Ieee754Float>(a: T, b: T) -> (T, T) {
     let x = a * b;
     (x, two_product_tail(a, b, x))
 }
 
 #[inline]
-fn two_product_tail(a: f64, b: f64, x: f64) -> f64 {
+fn two_product_tail<T: Ieee754Float>(a: T, b: T, x: T) -> T {
     let (ahi, alo) = split(a);
     let (bhi, blo) = split(b);
     let err1 = x - (ahi * bhi);
@@ -2010,8 +2177,8 @@ fn two_product_tail(a: f64, b: f64, x: f64) -> f64 {
 }
 
 #[inline]
-fn split(a: f64) -> (f64, f64) {
-    let c = SPLITTER * a;
+fn split<T: Ieee754Float>(a: T) -> (T, T) {
+    let c = T::SPLITTER * a;
     let abig = c - a;
     let ahi = c - abig;
     let alo = a - ahi;
@@ -2019,7 +2186,7 @@ fn split(a: f64) -> (f64, f64) {
 }
 
 #[inline]
-fn two_product_presplit(a: f64, b: f64, bhi: f64, blo: f64) -> (f64, f64) {
+fn two_product_presplit<T: Ieee754Float>(a: T, b: T, bhi: T, blo: T) -> (T, T) {
     let x = a * b;
     let (ahi, alo) = split(a);
     let err1 = x - ahi * bhi;
@@ -2030,27 +2197,27 @@ fn two_product_presplit(a: f64, b: f64, bhi: f64, blo: f64) -> (f64, f64) {
 }
 
 #[inline]
-fn two_two_diff(a1: f64, a0: f64, b1: f64, b0: f64) -> (f64, f64, f64, f64) {
+fn two_two_diff<T: Ieee754Float>(a1: T, a0: T, b1: T, b0: T) -> (T, T, T, T) {
     let (j, _r0, x0) = two_one_diff(a1, a0, b0);
     let (x3, x2, x1) = two_one_diff(j, _r0, b1);
     (x3, x2, x1, x0)
 }
 
 #[inline]
-fn two_one_diff(a1: f64, a0: f64, b: f64) -> (f64, f64, f64) {
+fn two_one_diff<T: Ieee754Float>(a1: T, a0: T, b: T) -> (T, T, T) {
     let (i, x0) = two_diff(a0, b);
     let (x2, x1) = two_sum(a1, i);
     (x2, x1, x0)
 }
 
 #[inline]
-fn two_diff(a: f64, b: f64) -> (f64, f64) {
+fn two_diff<T: Ieee754Float>(a: T, b: T) -> (T, T) {
     let x = a - b;
     (x, two_diff_tail(a, b, x))
 }
 
 #[inline]
-fn two_diff_tail(a: f64, b: f64, x: f64) -> f64 {
+fn two_diff_tail<T: Ieee754Float>(a: T, b: T, x: T) -> T {
     let bvirt = a - x;
     let avirt = x + bvirt;
     let bround = bvirt - b;
@@ -2059,13 +2226,13 @@ fn two_diff_tail(a: f64, b: f64, x: f64) -> f64 {
 }
 
 #[inline]
-fn two_sum(a: f64, b: f64) -> (f64, f64) {
+fn two_sum<T: Ieee754Float>(a: T, b: T) -> (T, T) {
     let x = a + b;
     (x, two_sum_tail(a, b, x))
 }
 
 #[inline]
-fn two_sum_tail(a: f64, b: f64, x: f64) -> f64 {
+fn two_sum_tail<T: Ieee754Float>(a: T, b: T, x: T) -> T {
     let bvirt = x - a;
     let avirt = x - bvirt;
     let bround = b - bvirt;
@@ -2073,7 +2240,7 @@ fn two_sum_tail(a: f64, b: f64, x: f64) -> f64 {
     around + bround
 }
 
-fn estimate(e: &[f64]) -> f64 {
+fn estimate<T: Ieee754Float>(e: &[T]) -> T {
     let mut q = e[0];
     for cur in &e[1..] {
         q += *cur;
@@ -2081,7 +2248,7 @@ fn estimate(e: &[f64]) -> f64 {
     q
 }
 
-fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
+fn fast_expansion_sum_zeroelim<T: Ieee754Float>(e: &[T], f: &[T], h: &mut [T]) -> usize {
     let mut enow = e[0];
     let mut fnow = f[0];
     let mut eindex = 0;
@@ -2113,7 +2280,7 @@ fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
             findex += 1;
         }
         Q = Qnew;
-        if hh != 0.0 {
+        if hh != T::from(0.0) {
             h[hindex] = hh;
             hindex += 1;
         }
@@ -2133,7 +2300,7 @@ fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
                 findex += 1;
             };
             Q = Qnew;
-            if hh != 0.0 {
+            if hh != T::from(0.0) {
                 h[hindex] = hh;
                 hindex += 1;
             }
@@ -2147,7 +2314,7 @@ fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
         hh = r.1;
         Q = Qnew;
         eindex += 1;
-        if hh != 0.0 {
+        if hh != T::from(0.0) {
             h[hindex] = hh;
             hindex += 1
         }
@@ -2160,13 +2327,13 @@ fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
         hh = r.1;
         Q = Qnew;
         findex += 1;
-        if hh != 0.0 {
+        if hh != T::from(0.0) {
             h[hindex] = hh;
             hindex += 1
         }
     }
 
-    if Q != 0.0 || hindex == 0 {
+    if Q != T::from(0.0) || hindex == 0 {
         h[hindex] = Q;
         hindex += 1;
     }
@@ -2174,19 +2341,19 @@ fn fast_expansion_sum_zeroelim(e: &[f64], f: &[f64], h: &mut [f64]) -> usize {
 }
 
 #[inline]
-fn fast_two_sum_tail(a: f64, b: f64, x: f64) -> f64 {
+fn fast_two_sum_tail<T: Ieee754Float>(a: T, b: T, x: T) -> T {
     let bvirt = x - a;
     b - bvirt
 }
 
 #[inline]
-fn fast_two_sum(a: f64, b: f64) -> (f64, f64) {
+fn fast_two_sum<T: Ieee754Float>(a: T, b: T) -> (T, T) {
     let x = a + b;
     (x, fast_two_sum_tail(a, b, x))
 }
 
 #[inline]
-fn square_tail(a: f64, x: f64) -> f64 {
+fn square_tail<T: Ieee754Float>(a: T, x: T) -> T {
     let (ahi, alo) = split(a);
     let err1 = x - ahi * ahi;
     let err3 = err1 - (ahi + ahi) * alo;
@@ -2194,27 +2361,27 @@ fn square_tail(a: f64, x: f64) -> f64 {
 }
 
 #[inline]
-fn square(a: f64) -> (f64, f64) {
+fn square<T: Ieee754Float>(a: T) -> (T, T) {
     let x = a * a;
     (x, square_tail(a, x))
 }
 
 #[inline]
-fn two_one_sum(a1: f64, a0: f64, b: f64) -> (f64, f64, f64) {
+fn two_one_sum<T: Ieee754Float>(a1: T, a0: T, b: T) -> (T, T, T) {
     let (_i, x0) = two_sum(a0, b);
     let (x2, x1) = two_sum(a1, _i);
     (x2, x1, x0)
 }
 
 #[inline]
-fn two_two_sum(a1: f64, a0: f64, b1: f64, b0: f64) -> (f64, f64, f64, f64) {
+fn two_two_sum<T: Ieee754Float>(a1: T, a0: T, b1: T, b0: T) -> (T, T, T, T) {
     let (_j, _r0, x0) = two_one_sum(a1, a0, b0);
     let (x3, x2, x1) = two_one_sum(_j, _r0, b1);
     (x3, x2, x1, x0)
 }
 
 #[inline]
-fn two_one_product(a1: f64, a0: f64, b: f64) -> (f64, f64, f64, f64) {
+fn two_one_product<T: Ieee754Float>(a1: T, a0: T, b: T) -> (T, T, T, T) {
     let (bhi, blo) = split(b);
     let (mut _i, x0) = two_product_presplit(a0, b, bhi, blo);
     let (mut _j, _0) = two_product_presplit(a1, b, bhi, blo);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,37 +63,37 @@ fn test_orient2d_fixtures() {
     })
 }
 
-#[cfg(all(not(feature = "no_std"), feature = "f128"))]
-#[test]
-fn test_orient2d_fixtures_f128() {
-    let f = filename_to_string("fixtures/orient2d.txt").unwrap();
-    let fixtures = results_by_line(&f);
-    fixtures.iter().enumerate().for_each(|(idx, fixture)| {
-        let ax = fixture[0] as f128;
-        let ay = fixture[1] as f128;
-        let bx = fixture[2] as f128;
-        let by = fixture[3] as f128;
-        let cx = fixture[4] as f128;
-        let cy = fixture[5] as f128;
-        let sign = fixture[6] as f128;
-        let c1 = CoordGeneric { x: ax, y: ay };
-        let c2 = CoordGeneric { x: bx, y: by };
-        let c3 = CoordGeneric { x: cx, y: cy };
-        let res = orient2d_generic(c1, c2, c3);
-        // result sign and fixture sign should be equal
-        assert!(
-            res.signum() == sign.signum(),
-            "Line {line:?}: Result sign ({result:?}) and fixture sign ({sign:?}) should match
-            \nCoord 1: {c1:?}\nCoord 2: {c2:?}\nCoord 3: {c3:?}",
-            line = idx + 1,
-            result = res,
-            sign = sign,
-            c1 = c1,
-            c2 = c2,
-            c3 = c3
-        );
-    })
-}
+//#[cfg(all(not(feature = "no_std"), feature = "f128"))]
+//#[test]
+//fn test_orient2d_fixtures_f128() {
+//    let f = filename_to_string("fixtures/orient2d.txt").unwrap();
+//    let fixtures = results_by_line(&f);
+//    fixtures.iter().enumerate().for_each(|(idx, fixture)| {
+//        let ax = fixture[0] as f128;
+//        let ay = fixture[1] as f128;
+//        let bx = fixture[2] as f128;
+//        let by = fixture[3] as f128;
+//        let cx = fixture[4] as f128;
+//        let cy = fixture[5] as f128;
+//        let sign = fixture[6] as f128;
+//        let c1 = CoordGeneric { x: ax, y: ay };
+//        let c2 = CoordGeneric { x: bx, y: by };
+//        let c3 = CoordGeneric { x: cx, y: cy };
+//        let res = orient2d_generic(c1, c2, c3);
+// result sign and fixture sign should be equal
+//        assert!(
+//            res.signum() == sign.signum(),
+//            "Line {line:?}: Result sign ({result:?}) and fixture sign ({sign:?}) should match
+//            \nCoord 1: {c1:?}\nCoord 2: {c2:?}\nCoord 3: {c3:?}",
+//            line = idx + 1,
+//            result = res,
+//            sign = sign,
+//            c1 = c1,
+//            c2 = c2,
+//            c3 = c3
+//        );
+//    })
+//}
 
 #[cfg(not(feature = "no_std"))]
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,9 @@
 // Fixtures copied from https://github.com/mourner/robust-predicates/tree/main/test/fixtures
 // Original location: https://www.cs.cmu.edu/afs/cs/project/pscico/pscico/src/arithmetic/compiler1/test/
 
-use super::{incircle, insphere, orient2d, orient3d, Coord, Coord3D};
+use super::{
+    incircle, insphere, orient2d, orient2d_generic, orient3d, Coord, Coord3D, CoordGeneric,
+};
 
 #[cfg(not(feature = "no_std"))]
 use std::fs::File;
@@ -57,6 +59,79 @@ fn test_orient2d_fixtures() {
             c1 = c1,
             c2 = c2,
             c3 = c3
+        );
+    })
+}
+
+#[cfg(all(not(feature = "no_std"), feature = "f128"))]
+#[test]
+fn test_orient2d_fixtures_f128() {
+    let f = filename_to_string("fixtures/orient2d.txt").unwrap();
+    let fixtures = results_by_line(&f);
+    fixtures.iter().enumerate().for_each(|(idx, fixture)| {
+        let ax = fixture[0] as f128;
+        let ay = fixture[1] as f128;
+        let bx = fixture[2] as f128;
+        let by = fixture[3] as f128;
+        let cx = fixture[4] as f128;
+        let cy = fixture[5] as f128;
+        let sign = fixture[6] as f128;
+        let c1 = CoordGeneric { x: ax, y: ay };
+        let c2 = CoordGeneric { x: bx, y: by };
+        let c3 = CoordGeneric { x: cx, y: cy };
+        let res = orient2d_generic(c1, c2, c3);
+        // result sign and fixture sign should be equal
+        assert!(
+            res.signum() == sign.signum(),
+            "Line {line:?}: Result sign ({result:?}) and fixture sign ({sign:?}) should match
+            \nCoord 1: {c1:?}\nCoord 2: {c2:?}\nCoord 3: {c3:?}",
+            line = idx + 1,
+            result = res,
+            sign = sign,
+            c1 = c1,
+            c2 = c2,
+            c3 = c3
+        );
+    })
+}
+
+#[cfg(not(feature = "no_std"))]
+#[test]
+fn test_orient2d_fixtures_f32() {
+    let f = filename_to_string("fixtures/orient2d.txt").unwrap();
+    let fixtures = results_by_line(&f);
+    fixtures.iter().enumerate().for_each(|(idx, fixture)| {
+        // Skip cases that may go out or range.
+        if fixture[0..6].iter().any(|&v| v.abs() > 1e18) ||
+            fixture[0..6].iter().any(|&v| v != 0.0 && v < 1e-11)
+        {
+            return;
+        }
+        let ax_f32 = fixture[0] as f32;
+        let ay_f32 = fixture[1] as f32;
+        let bx_f32 = fixture[2] as f32;
+        let by_f32 = fixture[3] as f32;
+        let cx_f32 = fixture[4] as f32;
+        let cy_f32 = fixture[5] as f32;
+        let c1_f32 = CoordGeneric { x: ax_f32, y: ay_f32 };
+        let c2_f32 = CoordGeneric { x: bx_f32, y: by_f32 };
+        let c3_f32 = CoordGeneric { x: cx_f32, y: cy_f32 };
+        let c1_f64 = Coord { x: ax_f32, y: ay_f32 };
+        let c2_f64 = Coord { x: bx_f32, y: by_f32 };
+        let c3_f64 = Coord { x: cx_f32, y: cy_f32 };
+        let res_f32 = orient2d_generic(c1_f32, c2_f32, c3_f32);
+        let res_f64 = orient2d(c1_f64, c2_f64, c3_f64);
+        // result sign in f32 should be equal to result sign in f64
+        assert!(
+            res_f32.signum() as f64 == res_f64.signum(),
+            "Line {line}: Result sign in f32 ({result_f32}) and result sign in 64 ({result_f64}) should match
+            \nCoord 1: {c1:?}\nCoord 2: {c2:?}\nCoord 3: {c3:?}",
+            line = idx + 1,
+            result_f32 = res_f32,
+            result_f64 = res_f64,
+            c1 = c1_f32,
+            c2 = c2_f32,
+            c3 = c3_f32
         );
     })
 }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users. (No changelog in project.)
---

This PR proposes making the implementation of the floating point predicate generic with respect to the floating-point type.

## Motivation
Interest in an f128-implementation was shown in https://github.com/georust/robust/issues/29#issuecomment-3001588259 . The current f64 implementation cannot solve predicates robustly for f128 and with this PR, f128 is supported when enabled (since the stable tool chain complains about it and I don't know how to make the stable tool chain just ignore it in Rust, it is currently commented out). While using f64 can evaluate predicates robustly for f32, there are platforms on which f32 ops are cheaper than f64, so having computation in f32 as an option could also be an improvement. It would work for f16 too but that may be a dubious choice for geometry due to low exponent range, so no test cases were included for that type. It will work for any other float type as well that satisifes the requirement and implements the newly added trait in this PR, which is a single line with the given macro.

## Changes
Adds Ieee754Float trait with an implementation macro, to generate the necessary constants for any float type that has ::EPSILON (for error bound computations), ::MANTISSA_DIGITS (for splitter computations), and the necesary arithmetic ops. Adds *Generic versions of Coord/Coord32 and _generic versions of orient2d, orient3d, incircle and insphere that require the new trait. Changes all other methods (which I consider implementation details that should generally not be called directly imho) to generic code that requires the new trait. Adds orient2d tests for f32 and f128 (commented out to avoid compiler error with the stabled tool chain).

## Design Choices
The function signatures of orient2d, orient3d, incircle and insphere, which should be the main API, remain unchanged, so that the default is converting to f64 and computing with that type. The actual computation is delegated to the _generic versions of those functions, which can also also be called with other types that implement the new trait. This choice is proposed because f64 is a good default that will work for f64, f32, f16, u8, ...,  i8, up to i32, is good (not optimal, though) for those integer types, and mitigate potential range limitations of f32 and especially f16. 

For public functions like *adapt or *exact, this PR changes the arguments from Into<f64> to requiring the new trait. I can change it, if that is undesirable.

## Background
The [original C implementation](https://www.[cs.cmu.edu/afs/cs/project/quake/public/code/predicates.c](https://www.cs.cmu.edu/afs/cs/project/quake/public/code/predicates.c)) is generic by allowing `REAL` to be defined as `float` or `double`. The current Rust implementation is for `f64` only.

The [underlying theory ](https://www.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps)of the algorithms used requires at least 6 mantissa digits, round-to-nearest, and tie-break to even default rounding mode, as specified in IEEE754. This is satisfied by f16, f32, f64, f128 and 80-bit extended precision on x86 (there is no f80 in rust, though). It implicitly requires that the values are in such that no overflows or denormalisations occur, which requires for a d-th degree predicate that the absolute values of the coordinates are zero or roughly within the d-th root of the minimum and maximum positive values of the floating point type. d is 2, 4, 3, and 5 for orient2d, incircle, orient3d and insphere respectively, so this allows values up to ~10^19 for f32 for orient2d, up to 10^7 for insphere, etc., so this is reasonable for f32 and upwards.

